### PR TITLE
feat(teleport): improve force materialization reliability and add stuck character logging

### DIFF
--- a/Database/Updates/Log/AddStuckCharacterLogFeature.sql
+++ b/Database/Updates/Log/AddStuckCharacterLogFeature.sql
@@ -1,0 +1,27 @@
+USE `ace_log`;
+
+--
+-- Table structure for table stuck_character_log
+--
+
+DROP TABLE IF EXISTS `stuck_character_log`;
+
+CREATE TABLE `stuck_character_log` (
+  `stuckCharacterLogId` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of the stuck character log',
+  `playerGuid` INT UNSIGNED,
+  `playerName` VARCHAR(255),
+  `accountName` VARCHAR(255),
+  `accountId` INT UNSIGNED,
+  `sessionInfo` VARCHAR(255),
+  `landblock` VARCHAR(50),
+  `location` VARCHAR(255),
+  `isLoggingOut` BIT,
+  `isInDeathProcess` BIT,
+  `foundOnLandblock` BIT,
+  `forcedLogOffRequested` BIT,
+  `pkLogoutState` INT UNSIGNED,
+  `materializedLogoutState` INT UNSIGNED,
+  `logoffPath` VARCHAR(500),
+  `createdAtUtc` DATETIME,
+  PRIMARY KEY (`stuckCharacterLogId`)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4;

--- a/Source/ACE.Database/LogDatabase.cs
+++ b/Source/ACE.Database/LogDatabase.cs
@@ -558,6 +558,48 @@ namespace ACE.Database
 
         #endregion
 
+        #region Stuck Character Log
+        public void LogStuckCharacter(StuckCharacterLog stuckLog)
+        {
+            if (stuckLog == null)
+                return;
+
+            try
+            {
+                using (var context = new LogDbContext())
+                {
+                    context.Database.ExecuteSql(
+                        @$"INSERT INTO stuck_character_log 
+                        (playerGuid, playerName, accountName, accountId, sessionInfo, landblock, location,
+                         isLoggingOut, isInDeathProcess, foundOnLandblock, forcedLogOffRequested,
+                         pkLogoutState, materializedLogoutState, logoffPath, createdAtUtc)
+                        VALUES
+                        ({stuckLog.PlayerGuid},
+                         {stuckLog.PlayerName ?? (object)DBNull.Value},
+                         {stuckLog.AccountName ?? (object)DBNull.Value},
+                         {stuckLog.AccountId},
+                         {stuckLog.SessionInfo ?? (object)DBNull.Value},
+                         {stuckLog.Landblock ?? (object)DBNull.Value},
+                         {stuckLog.Location ?? (object)DBNull.Value},
+                         {stuckLog.IsLoggingOut},
+                         {stuckLog.IsInDeathProcess},
+                         {stuckLog.FoundOnLandblock},
+                         {stuckLog.ForcedLogOffRequested},
+                         {stuckLog.PkLogoutState},
+                         {stuckLog.MaterializedLogoutState},
+                         {stuckLog.LogoffPath ?? (object)DBNull.Value},
+                         {DateTime.Now});");
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error($"Exception in LogStuckCharacter saving stuck character event to DB. ex: {ex}");
+            }
+
+            return;
+        }
+        #endregion
+
         //public bool ExampleCustomSql()
         //{            
         //    var sql = @$"";

--- a/Source/ACE.Database/Models/Log/LogDbContext.cs
+++ b/Source/ACE.Database/Models/Log/LogDbContext.cs
@@ -31,6 +31,7 @@ namespace ACE.Database.Models.Log
 
         public virtual DbSet<RareLog> RareLogs { get; set; }
 
+        public virtual DbSet<StuckCharacterLog> StuckCharacterLogs { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -355,6 +356,62 @@ namespace ACE.Database.Models.Log
 
                 entity.Property(e => e.CreatedDateTime)
                     .HasColumnName("createDateTime");               
+            });
+
+            modelBuilder.Entity<StuckCharacterLog>(entity =>
+            {
+                entity.HasKey(e => e.Id)
+                    .HasName("PRIMARY");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("stuckCharacterLogId");
+
+                entity.ToTable("stuck_character_log");
+
+                entity.Property(e => e.PlayerGuid)
+                    .HasColumnName("playerGuid");
+
+                entity.Property(e => e.PlayerName)
+                    .HasColumnName("playerName");
+
+                entity.Property(e => e.AccountName)
+                    .HasColumnName("accountName");
+
+                entity.Property(e => e.AccountId)
+                    .HasColumnName("accountId");
+
+                entity.Property(e => e.SessionInfo)
+                    .HasColumnName("sessionInfo");
+
+                entity.Property(e => e.Landblock)
+                    .HasColumnName("landblock");
+
+                entity.Property(e => e.Location)
+                    .HasColumnName("location");
+
+                entity.Property(e => e.IsLoggingOut)
+                    .HasColumnName("isLoggingOut");
+
+                entity.Property(e => e.IsInDeathProcess)
+                    .HasColumnName("isInDeathProcess");
+
+                entity.Property(e => e.FoundOnLandblock)
+                    .HasColumnName("foundOnLandblock");
+
+                entity.Property(e => e.ForcedLogOffRequested)
+                    .HasColumnName("forcedLogOffRequested");
+
+                entity.Property(e => e.PkLogoutState)
+                    .HasColumnName("pkLogoutState");
+
+                entity.Property(e => e.MaterializedLogoutState)
+                    .HasColumnName("materializedLogoutState");
+
+                entity.Property(e => e.LogoffPath)
+                    .HasColumnName("logoffPath");
+
+                entity.Property(e => e.CreatedAtUtc)
+                    .HasColumnName("createdAtUtc");
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/Source/ACE.Database/Models/Log/StuckCharacterLog.cs
+++ b/Source/ACE.Database/Models/Log/StuckCharacterLog.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace ACE.Database.Models.Log
+{
+    public class StuckCharacterLog
+    {
+        public long Id { get; set; }
+
+        public uint PlayerGuid { get; set; }
+        public string PlayerName { get; set; }
+
+        public string AccountName { get; set; }
+        public int AccountId { get; set; }
+
+        public string SessionInfo { get; set; }
+
+        public string Landblock { get; set; }
+        public string Location { get; set; }
+
+        public bool IsLoggingOut { get; set; }
+        public bool IsInDeathProcess { get; set; }
+        public bool FoundOnLandblock { get; set; }
+        public bool ForcedLogOffRequested { get; set; }
+        public uint PkLogoutState { get; set; }
+        public uint MaterializedLogoutState { get; set; }
+
+        public string LogoffPath { get; set; }
+
+        public DateTime CreatedAtUtc { get; set; }
+    }
+}

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -5,12 +5,10 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime;
 using System.Threading.Tasks;
-
-using log4net;
-
 using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database;
+using ACE.Database.Models.Log;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.DatLoader;
@@ -32,8 +30,7 @@ using ACE.Server.Physics.Extensions;
 using ACE.Server.Physics.Managers;
 using ACE.Server.WorldObjects;
 using ACE.Server.WorldObjects.Entity;
-
-
+using log4net;
 using Position = ACE.Entity.Position;
 using Spell = ACE.Server.Entity.Spell;
 
@@ -2437,102 +2434,129 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("forcelogoff", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Force log off of specified character or last appraised character")]
         public static void HandleForceLogoff(Session session, params string[] parameters)
         {
-            var playerName = "";
-            if (parameters.Length > 0)
-                playerName = string.Join(" ", parameters);
-
+            var playerName = parameters.Length > 0 ? string.Join(" ", parameters) : "";
             WorldObject target = null;
 
             if (!string.IsNullOrEmpty(playerName))
             {
                 var plr = PlayerManager.FindByName(playerName);
-                if (plr != null)
-                {
-                    target = PlayerManager.GetOnlinePlayer(plr.Guid);
-
-                    if (target == null)
-                    {
-                        CommandHandlerHelper.WriteOutputInfo(session, $"Unable to force log off for {plr.Name}: Player is not online.");
-                        return;
-                    }
-                }
-                else
+                if (plr == null)
                 {
                     CommandHandlerHelper.WriteOutputInfo(session, $"Unable to force log off for {playerName}: Player not found in manager.");
                     return;
                 }
+
+                target = PlayerManager.GetOnlinePlayer(plr.Guid);
+                if (target == null)
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Unable to force log off for {plr.Name}: Player is not online.");
+                    return;
+                }
             }
             else
-                target = CommandHandlerHelper.GetLastAppraisedObject(session);
-
-            if (target != null && target is Player player)
             {
-                //if (player.Session != null)
-                //    player.Session.LogOffPlayer(true);
-                //else
-                //    player.LogOut();
-
-                var msg = $"Player {player.Name} (0x{player.Guid}) found in PlayerManager.onlinePlayers.\n";
-                msg += $"------- Session: {(player.Session != null ? $"C2S: {player.Session.EndPointC2S} | S2C: {player.Session.EndPointS2C}" : "NULL")}\n";
-                msg += $"------- CurrentLandblock: {(player.CurrentLandblock != null ? $"0x{player.CurrentLandblock.Id:X4}" : "NULL")}\n";
-                msg += $"------- Location: {(player.Location != null ? $"{player.Location.ToLOCString()}" : "NULL")}\n";
-                msg += $"------- IsLoggingOut: {player.IsLoggingOut}\n";
-                msg += $"------- IsInDeathProcess: {player.IsInDeathProcess}\n";
-                var foundOnLandblock = false;
-                if (player.CurrentLandblock != null)
-                    foundOnLandblock = LandblockManager.GetLandblock(player.CurrentLandblock.Id, false).GetObject(player.Guid) != null;
-                msg += $"------- FoundOnLandblock: {foundOnLandblock}\n";
-                var playerForcedLogOffRequested = player.ForcedLogOffRequested;
-                msg += $"------- ForcedLogOffRequested: {playerForcedLogOffRequested}\n";
-
-                msg += "Log off path taken: ";
-                if (playerForcedLogOffRequested)
-                {
-                    player.Session?.Terminate(Network.Enum.SessionTerminationReason.ForcedLogOffRequested, new GameMessageBootAccount(" because the character was forced to log off by an admin"));
-                    player.ForceLogoff();
-                    msg += "player.Session?.Terminate() | player.ForceLogoff()";
-                }
-                else if (player.Session != null)
-                {
-                    player.ForcedLogOffRequested = true;
-                    player.Session.Terminate(Network.Enum.SessionTerminationReason.ForcedLogOffRequested, new GameMessageBootAccount(" because the character was forced to log off by an admin"));
-                    msg += "player.ForcedLogOffRequested = true | player.Session.Terminate()";
-                }
-                else if (player.CurrentLandblock != null && foundOnLandblock)
-                {
-                    player.ForcedLogOffRequested = true;
-                    player.LogOut();
-                    msg += "player.ForcedLogOffRequested = true | player.LogOut()";
-                }
-                else if (player.IsInDeathProcess)
-                {
-                    player.ForcedLogOffRequested = true;
-                    player.IsInDeathProcess = false;
-                    player.LogOut_Inner(true);
-                    msg += "player.ForcedLogOffRequested = true | player.IsInDeathProcess = false | player.LogOut_Inner(true)";
-                }
-                else
-                {
-                    player.ForcedLogOffRequested = true;
-                    msg += "player.ForcedLogOffRequested = true";
-                }
-
-                if (!playerForcedLogOffRequested)
-                    msg += "\nUse this command again if this player does not properly log off within the next minute.";
-                else
-                    msg += "\nPlease send the above report to ACEmulator development team via Discord.";
-
-                CommandHandlerHelper.WriteOutputInfo(session, msg);
-
-                PlayerManager.BroadcastToAuditChannel(session?.Player, $"Forcing Log Off of {player.Name}...");
+                target = CommandHandlerHelper.GetLastAppraisedObject(session);
             }
-            else
+
+            if (target is not Player player)
             {
                 if (target != null)
                     CommandHandlerHelper.WriteOutputInfo(session, $"Unable to force log off for {target.Name}: Target is not a player.");
-                //else
-                //    CommandHandlerHelper.WriteOutputInfo(session, $"Unable to force log off for {playerName}: Player not found in manager.");
+                return;
             }
+
+            var foundOnLandblock = player.CurrentLandblock != null &&
+                LandblockManager.GetLandblock(player.CurrentLandblock.Id, false).GetObject(player.Guid) != null;
+
+            var wasForced = player.ForcedLogOffRequested;
+
+            var logoffPath = ExecuteLogoff(player, foundOnLandblock);
+
+            var msg =
+                $"Player {player.Name} (0x{player.Guid}) found in PlayerManager.onlinePlayers.\n" +
+                $"------- Session: {(player.Session != null ? $"C2S: {player.Session.EndPointC2S} | S2C: {player.Session.EndPointS2C}" : "NULL")}\n" +
+                $"------- CurrentLandblock: {(player.CurrentLandblock != null ? $"0x{player.CurrentLandblock.Id:X4}" : "NULL")}\n" +
+                $"------- Location: {player.Location?.ToLOCString() ?? "NULL"}\n" +
+                $"------- IsLoggingOut: {player.IsLoggingOut}\n" +
+                $"------- IsInDeathProcess: {player.IsInDeathProcess}\n" +
+                $"------- MaterializedLogoutState: {player.MaterializedLogoutState.ToString()}\n" +
+                $"------- PkLogoutState: {player.PkLogoutState.ToString()}\n" +
+                $"------- FoundOnLandblock: {foundOnLandblock}\n" +
+                $"------- ForcedLogOffRequested: {player.ForcedLogOffRequested}\n" +
+                $"Log off path taken: {logoffPath}";
+
+            msg += !wasForced
+                ? "\nUse this command again if this player does not properly log off within the next minute."
+                : "\nPlease send the above report to ACEmulator development team via Discord.";
+
+            DatabaseManager.Log.LogStuckCharacter(new StuckCharacterLog
+            {
+                PlayerGuid = player.Guid.Full,
+                PlayerName = player.Name,
+                AccountName = player.Account?.AccountName,
+                AccountId = (int)(player.Account?.AccountId ?? 0),
+
+                SessionInfo = player.Session != null
+                    ? $"C2S: {player.Session.EndPointC2S} | S2C: {player.Session.EndPointS2C}"
+                    : "NULL",
+
+                Landblock = player.CurrentLandblock != null
+                    ? $"0x{player.CurrentLandblock.Id:X4}"
+                    : "NULL",
+
+                Location = player.Location?.ToLOCString() ?? "NULL",
+
+                IsLoggingOut = player.IsLoggingOut,
+                IsInDeathProcess = player.IsInDeathProcess,
+                MaterializedLogoutState = (uint)player.MaterializedLogoutState,
+                PkLogoutState = (uint)player.PkLogoutState,
+                FoundOnLandblock = foundOnLandblock,
+                ForcedLogOffRequested = player.ForcedLogOffRequested,
+
+                LogoffPath = logoffPath,
+                CreatedAtUtc = DateTime.UtcNow
+            });
+
+            CommandHandlerHelper.WriteOutputInfo(session, msg);
+
+            PlayerManager.BroadcastToAuditChannel(session?.Player, $"Forcing Log Off of {player.Name}...");
+        }
+
+        private static string ExecuteLogoff(Player player, bool foundOnLandblock)
+        {
+            if (player.ForcedLogOffRequested)
+            {
+                player.Session?.Terminate(Network.Enum.SessionTerminationReason.ForcedLogOffRequested,
+                    new GameMessageBootAccount(" because the character was forced to log off by an admin"));
+                player.ForceLogoff();
+                return "Session.Terminate | ForceLogoff";
+            }
+
+            if (player.Session != null)
+            {
+                player.ForcedLogOffRequested = true;
+                player.Session.Terminate(Network.Enum.SessionTerminationReason.ForcedLogOffRequested,
+                    new GameMessageBootAccount(" because the character was forced to log off by an admin"));
+                return "ForcedLogOffRequested = true | Session.Terminate";
+            }
+
+            if (player.CurrentLandblock != null && foundOnLandblock)
+            {
+                player.ForcedLogOffRequested = true;
+                player.LogOut();
+                return "ForcedLogOffRequested = true | LogOut";
+            }
+
+            if (player.IsInDeathProcess)
+            {
+                player.ForcedLogOffRequested = true;
+                player.IsInDeathProcess = false;
+                player.LogOut_Inner(true);
+                return "ForcedLogOffRequested = true | ClearDeath | LogOut_Inner";
+            }
+
+            player.ForcedLogOffRequested = true;
+            return "ForcedLogOffRequested = true";
         }
 
         [CommandHandler("showsession", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Show IP and ID for network session of last appraised character")]

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2468,7 +2468,12 @@ namespace ACE.Server.Command.Handlers
             var foundOnLandblock = player.CurrentLandblock != null &&
                 LandblockManager.GetLandblock(player.CurrentLandblock.Id, false).GetObject(player.Guid) != null;
 
+            // capture state before logoff for message and DB log
             var wasForced = player.ForcedLogOffRequested;
+            var wasInDeathProcess = player.IsInDeathProcess;
+            var wasLoggingOut = player.IsLoggingOut;
+            var pkState = player.PkLogoutState;
+            var matState = player.MaterializedLogoutState;
 
             var logoffPath = ExecuteLogoff(player, foundOnLandblock);
 
@@ -2477,12 +2482,12 @@ namespace ACE.Server.Command.Handlers
                 $"------- Session: {(player.Session != null ? $"C2S: {player.Session.EndPointC2S} | S2C: {player.Session.EndPointS2C}" : "NULL")}\n" +
                 $"------- CurrentLandblock: {(player.CurrentLandblock != null ? $"0x{player.CurrentLandblock.Id:X4}" : "NULL")}\n" +
                 $"------- Location: {player.Location?.ToLOCString() ?? "NULL"}\n" +
-                $"------- IsLoggingOut: {player.IsLoggingOut}\n" +
-                $"------- IsInDeathProcess: {player.IsInDeathProcess}\n" +
-                $"------- MaterializedLogoutState: {player.MaterializedLogoutState.ToString()}\n" +
-                $"------- PkLogoutState: {player.PkLogoutState.ToString()}\n" +
+                $"------- IsLoggingOut: {wasLoggingOut}\n" +
+                $"------- IsInDeathProcess: {wasInDeathProcess}\n" +
+                $"------- MaterializedLogoutState: {matState.ToString()}\n" +
+                $"------- PkLogoutState: {pkState.ToString()}\n" +
                 $"------- FoundOnLandblock: {foundOnLandblock}\n" +
-                $"------- ForcedLogOffRequested: {player.ForcedLogOffRequested}\n" +
+                $"------- ForcedLogOffRequested: {wasForced}\n" +
                 $"Log off path taken: {logoffPath}";
 
             msg += !wasForced
@@ -2506,12 +2511,12 @@ namespace ACE.Server.Command.Handlers
 
                 Location = player.Location?.ToLOCString() ?? "NULL",
 
-                IsLoggingOut = player.IsLoggingOut,
-                IsInDeathProcess = player.IsInDeathProcess,
-                MaterializedLogoutState = (uint)player.MaterializedLogoutState,
-                PkLogoutState = (uint)player.PkLogoutState,
+                IsLoggingOut = wasLoggingOut,
+                IsInDeathProcess = wasInDeathProcess,
+                ForcedLogOffRequested = wasForced,
                 FoundOnLandblock = foundOnLandblock,
-                ForcedLogOffRequested = player.ForcedLogOffRequested,
+                PkLogoutState = (uint)pkState,
+                MaterializedLogoutState = (uint)matState,
 
                 LogoffPath = logoffPath,
                 CreatedAtUtc = DateTime.UtcNow

--- a/Source/ACE.Server/Entity/Arena/ArenaLocation.cs
+++ b/Source/ACE.Server/Entity/Arena/ArenaLocation.cs
@@ -229,7 +229,7 @@ namespace ACE.Server.Entity
                                         if(teamPlayer != null)
                                         {
                                             log.Info($"ArenaLocation.Tick() - {ArenaName} status = 2 - teleporting {teamPlayer.Name} to position {teamPosition.Value.ToLOCString}");
-                                            teamPlayer.Teleport(teamPosition.Value, force: true);
+                                            teamPlayer.Teleport(teamPosition.Value);
                                         }
                                     }
                                 }
@@ -240,7 +240,7 @@ namespace ACE.Server.Entity
                                 {
                                     var j = i < positions.Count ? i : positions.Count - 1;
                                     log.Info($"ArenaLocation.Tick() - {ArenaName} status = 2 - teleporting {playerList[i].Name} to position {positions[j].ToLOCString}");
-                                    playerList[i].Teleport(positions[j], force: true);
+                                    playerList[i].Teleport(positions[j]);
                                 }
                             }
 
@@ -461,7 +461,7 @@ namespace ACE.Server.Entity
                                     if (player.CurrentLandblock?.IsArenaLandblock ?? false)
                                     {
                                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Thank you for playing arenas.  You've loitered a bit too long after the event.  Have a nice trip to your Lifestone!", ChatMessageType.System));
-                                        player.Teleport(player.Sanctuary, force: true);
+                                        player.Teleport(player.Sanctuary);
                                     }
                                 }
                             }
@@ -1703,7 +1703,7 @@ namespace ACE.Server.Entity
                         continue;
                     }
 
-                    player.Teleport(player.Sanctuary, force: true);
+                    player.Teleport(player.Sanctuary);
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat("You've been teleported to your lifestone because you were inside an arena location without being an active participant in an arena event", ChatMessageType.System));
                 }
             }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -406,7 +406,7 @@ namespace ACE.Server.Entity
                                 {
                                     //Teleport to LS
                                     playerToKick.Session.Network.EnqueueSend(new GameMessageSystemChat("You have violated the max number of members allowed inside of a zerg restricted area.  Fuck you.", ChatMessageType.Broadcast));
-                                    playerToKick.Teleport(playerToKick.Sanctuary, force: true);
+                                    playerToKick.Teleport(playerToKick.Sanctuary);
                                 }
                                 catch (Exception ex)
                                 {
@@ -423,7 +423,7 @@ namespace ACE.Server.Entity
                         {
                             var currPlayer = (Player)disallowedPlayer;
                             currPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat("You have violated the whitelist inside of a zerg restricted area.  Fuck you.", ChatMessageType.Broadcast));
-                            currPlayer.Teleport(currPlayer.Sanctuary, force: true);
+                            currPlayer.Teleport(currPlayer.Sanctuary);
                         }
                         catch (Exception ex)
                         {

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -381,5 +381,16 @@ namespace ACE.Server.Entity
             var currentLb = $"{currentLbRaw:X8}".Substring(0, 4);
             return currentLb;
         }
+
+        public static bool IsValidPosition(this Position pos)
+        {
+            if (pos.Landblock == 0)
+                return false;
+            if (float.IsNaN(pos.PositionX) || float.IsNaN(pos.PositionY) || float.IsNaN(pos.PositionZ))
+                return false;
+            if (!pos.Rotation.IsRotationValid())
+                return false;
+            return true;
+        }
     }
 }

--- a/Source/ACE.Server/Managers/ArenaManager.cs
+++ b/Source/ACE.Server/Managers/ArenaManager.cs
@@ -677,7 +677,7 @@ namespace ACE.Server.Managers
                         //If player is in an arena, teleport player to their LS
                         if (player.CurrentLandblock?.IsArenaLandblock ?? false)
                         {
-                            player.Teleport(player.Sanctuary, force: true);
+                            player.Teleport(player.Sanctuary);
                         }
                     }
                 }
@@ -974,7 +974,7 @@ namespace ACE.Server.Managers
                 if (startingPositions != null)
                 {
                     //Teleport to a random starting position
-                    player.Teleport(startingPositions[new Random().Next(startingPositions.Count)], force: true);                    
+                    player.Teleport(startingPositions[new Random().Next(startingPositions.Count)]);                    
                 }
             });
             actionChain.AddAction(player, () =>
@@ -1004,7 +1004,7 @@ namespace ACE.Server.Managers
             actionChain.AddDelaySeconds(3);
             actionChain.AddAction(player, () =>
             {
-                player.Teleport(player.Sanctuary, force: true);
+                player.Teleport(player.Sanctuary);
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You've exited observer mode for an arena match and are being teleported to your lifestone.", ChatMessageType.System));                
             });
             actionChain.AddDelaySeconds(0.5);

--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -154,6 +154,14 @@ namespace ACE.Server.Managers
             }
         }
 
+        public static bool IsInLogoffQueue(Player player)
+        {
+            if (player == null)
+                return false;
+
+            return playersPendingLogoff.Contains(player);
+        }
+
         /// <summary>
         /// This will save any player in the OfflinePlayers dictionary that has ChangesDetected. The biotas are saved in parallel.
         /// </summary>

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -626,6 +626,7 @@ namespace ACE.Server.Managers
                 ("tinker_lotto_enabled", new Property<bool>(false, "enables the tinkering lotto feature")),
                 ("force_logout_materialization", new Property<bool>(true, "forces players to materialize on logut")),
                 ("force_teleport_materialization", new Property<bool>(true, "forces players to materialize on teleport")),
+                ("force_login_materialization", new Property<bool>(true, "forces players to materialize on login")),
                 ("disable_pvp_cleave", new Property<bool>(false, "disables melee cleave attacks from targeting players")),
                 ("disable_world_bosses", new Property<bool>(true, "disables spawning of world bosses")),
                 ("jump_cancels_melee", new Property<bool>(false, "cancels melee attacks when the target is jumping")),
@@ -637,6 +638,7 @@ namespace ACE.Server.Managers
                 ("bounty_allow_logged_out", new Property<bool>(false, "enable this to allow logged out characters to be valid bounties")),
                 ("bounty_pk_timer_active_enabled", new Property<bool>(true, "enable this for custom bounty pk timer active check")),
                 ("bounty_expirations_enabled", new Property<bool>(true, "enable this to allow bounties to expire")),
+                ("recent_teleport_prevention", new Property<bool>(true, "enable this to prevent players from teleporting too frequently")),
                 ("local_server", new Property<bool>(false, "Do not enable on live servers! Enable this to allow for server behavior to change as necessary for testing envrionments.")),
                 ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world"))
                 );
@@ -811,6 +813,7 @@ namespace ACE.Server.Managers
                 ("dungeoncontrol_capturescore_mod", new Property<double>(1.0, "modifies the score needed to capture a dungeon in dungeon control, generally used for testing")),
                 ("force_logout_materialization_duration", new Property<double>(1, "the number of seconds a player should materialize for before logging out")),
                 ("force_teleport_materialization_duration", new Property<double>(10.0, "the number of seconds after teleporting that a player should force materialize")),
+                ("force_login_materialization_duration", new Property<double>(10.0, "the number of seconds after logging in that a player should force materialize")),
                 ("bounty_last_location_duration", new Property<double>(30.0, "the number of seconds before a player can use the bounty contract's location finder again")),
                 ("recent_teleport_threshold", new Property<double>(3.0, "the number of seconds after materializing that a player can teleport again"))
                 

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -253,6 +253,14 @@ namespace ACE.Server.Managers
                     session.Player.Location = new Position(0xA9B40019, 84, 7.1f, 94, 0, 0, -0.0784591f, 0.996917f);  // ultimate fallback
             }
 
+            // If the client is logging into an invalid position
+            if (!session.Player.Location.IsValidPosition())
+            {
+                var fallbackPosition = new Position(session.Player.FallbackPosition);
+                session.Player.Location = new Position(fallbackPosition);
+                log.Warn($"Player {session.Player.Name} logged in with invalid position, relocating to {fallbackPosition.ToLOCString()}");
+            } 
+
             //Handle logging into arena
             if(ArenaLocation.IsArenaLandblock(session.Player.Location?.Landblock ?? 0))
             {

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -400,7 +400,7 @@ namespace ACE.Server.Managers
                 actionChain.AddAction(session.Player, () =>
                 {
                     if (session != null && session.Player != null)
-                        session.Player.Teleport(fixLoc, force: true);
+                        session.Player.Teleport(fixLoc);
                 });
                 actionChain.EnqueueChain();
             }
@@ -440,15 +440,6 @@ namespace ACE.Server.Managers
                 session.Network.EnqueueSend(new GameMessageSystemChat("You have returned to the Olthoi Queen to serve the hive.", ChatMessageType.Broadcast));
             else if (playerLoggedInOnNoLogLandblock) // see http://acpedia.org/wiki/Mount_Elyrii_Hive
                 session.Network.EnqueueSend(new GameMessageSystemChat("The currents of portal space cannot return you from whence you came. Your previous location forbids login.", ChatMessageType.Broadcast));            
-
-            // Force a materialization when logging in
-            if (session.Player.ForceTeleportMaterialization)
-            {
-                var actionChain = new ActionChain();
-                actionChain.AddDelaySeconds(session.Player.TeleportMaterializedDuration);
-                actionChain.AddAction(session.Player, session.Player.OnTeleportComplete);
-                actionChain.EnqueueChain();
-            }
         }
 
         private static string AppendLines(params string[] lines)
@@ -468,7 +459,7 @@ namespace ACE.Server.Managers
         /// Note that this work will be done on the next tick, not immediately, so be careful about your order of operations.
         /// If you must ensure order, pass your follow up work in with the argument actionToFollowUpWith. That work will be enqueued onto the Player.
         /// </summary>
-        public static void ThreadSafeTeleport(Player player, Position newPosition, IAction actionToFollowUpWith = null, bool fromPortal = false, bool force = false)
+        public static void ThreadSafeTeleport(Player player, Position newPosition, IAction actionToFollowUpWith = null, bool fromPortal = false, bool force = true)
         {
             EnqueueAction(new ActionEventDelegate(() =>
             {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionAdvocateTeleport.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionAdvocateTeleport.cs
@@ -35,7 +35,7 @@ namespace ACE.Server.Network.GameAction.Actions
             position.AdjustMapCoords();
 
             ChatPacket.SendServerMessage(session, $"Teleporting to: ({position.GetMapCoordStr()})", ChatMessageType.Broadcast);
-            session.Player.Teleport(position, force: true);
+            session.Player.Teleport(position);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionLoginComplete.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionLoginComplete.cs
@@ -10,7 +10,7 @@ namespace ACE.Server.Network.GameAction.Actions
         [GameAction(GameActionType.LoginComplete)]
         public static void Handle(ClientMessage message, Session session)
         {
-            session.Player.OnTeleportComplete();
+            session.Player.OnTeleportComplete(session.Player.CurrentTeleportId);
 
             if (!session.Player.FirstEnterWorldDone)
             {

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -221,7 +221,7 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     var islandLoc = new Position(0xF76B0036, 148.463013f, 138.334213f, 0.00500f, 0f, 0f, -0.530781f, -0.847509f);
-                    player.Teleport(islandLoc);
+                    player.Teleport(islandLoc, force: false);
                     var playerMsg = $"The {this.Name} has teleported you to Peddler's Outpost.";
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat(playerMsg, ChatMessageType.Broadcast));
                 }
@@ -241,7 +241,7 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     var shoushiTCLoc = new Position(0xDE510016, 48.076149f, 121.470108f, 16.005001f, 0f, 0f, -0.999995f, 0.003087f);
-                    player.Teleport(shoushiTCLoc);
+                    player.Teleport(shoushiTCLoc, force: false);
                     var playerMsg = $"The {this.Name} has teleported you to the Shoushi Outpost.";
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat(playerMsg, ChatMessageType.Broadcast));
                 }
@@ -261,7 +261,7 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     var yaraqTCLoc = new Position(0x81640006, 0.576489f, 143.601151f, 0.699269f, 0f, 0f, -0.714859f, 0.697868f);
-                    player.Teleport(yaraqTCLoc);
+                    player.Teleport(yaraqTCLoc, force: false);
                     var playerMsg = $"The {this.Name} has teleported you to the Yaraq Outpost.";
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat(playerMsg, ChatMessageType.Broadcast));
                 }
@@ -281,7 +281,7 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     var holtburgTCLoc = new Position(0xA5B4003B, 176.617722f, 71.680115f, 46.005001f, 0f, 0f, 0.716226f, 0.697868f);
-                    player.Teleport(holtburgTCLoc);
+                    player.Teleport(holtburgTCLoc, force: false);
                     var playerMsg = $"The {this.Name} has teleported you to the Holtburg Outpost.";
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat(playerMsg, ChatMessageType.Broadcast));
                 }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1352,7 +1352,7 @@ namespace ACE.Server.WorldObjects.Managers
                                 var destination = new Position(emote.ObjCellId.Value, emote.OriginX.Value, emote.OriginY.Value, emote.OriginZ.Value, emote.AnglesX.Value, emote.AnglesY.Value, emote.AnglesZ.Value, emote.AnglesW.Value);
 
                                 WorldObject.AdjustDungeon(destination);
-                                WorldManager.ThreadSafeTeleport(player, destination, force: true);
+                                WorldManager.ThreadSafeTeleport(player, destination);
                             }
                             else // position is relative to WorldObject's current location
                             {
@@ -1362,7 +1362,7 @@ namespace ACE.Server.WorldObjects.Managers
                                 relativeDestination.LandblockId = new LandblockId(relativeDestination.GetCell());
 
                                 WorldObject.AdjustDungeon(relativeDestination);
-                                WorldManager.ThreadSafeTeleport(player, relativeDestination, force: true);
+                                WorldManager.ThreadSafeTeleport(player, relativeDestination);
                             }
                         }
                     }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -160,7 +160,7 @@ namespace ACE.Server.WorldObjects
 
             // set pink bubble state
             IgnoreCollisions = true; ReportCollisions = false; Hidden = true;
-        }
+         }
 
         private void SetEphemeralValues()
         {
@@ -522,7 +522,7 @@ namespace ACE.Server.WorldObjects
 
         public bool ForceLogoutMaterialization => PropertyManager.GetBool("force_logout_materialization").Item;
 
-        public double MaterializedLogoutDuration => PropertyManager.GetDouble("force_logout_materialization_duration").Item;
+        public double ForceLogoutMaterializationDuration => PropertyManager.GetDouble("force_logout_materialization_duration").Item;
 
         public enum LogoutState
         {
@@ -580,11 +580,8 @@ namespace ACE.Server.WorldObjects
         {
             PkLogoutState = LogoutState.InProgress;
             PKLogout = true;
-
-            if (ForceLogoutMaterialization)
-                OnTeleportComplete();
-
             IsFrozen = true;
+
             EnqueueBroadcastPhysicsState();
 
             //Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouHaveBeenInPKBattleTooRecently));
@@ -610,7 +607,7 @@ namespace ACE.Server.WorldObjects
 
             if (Teleporting && MaterializedLogoutState is LogoutState.Pending)
             {
-                ForceMaterialize();
+                ForceMaterializeForLogoff();
                 return false;
             }
 
@@ -618,11 +615,15 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
-        public void ForceMaterialize()
+        public void ForceMaterializeForLogoff()
         {
             MaterializedLogoutState = LogoutState.InProgress;
-            OnTeleportComplete();
-            LogoffTimestamp = Time.GetFutureUnixTime(MaterializedLogoutDuration);
+
+            _teleportId++;
+
+            OnTeleportComplete(_teleportId);
+
+            LogoffTimestamp = Time.GetFutureUnixTime(ForceLogoutMaterializationDuration);
             PlayerManager.AddPlayerToLogoffQueue(this);
         }
 

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -541,7 +541,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool LogOut(bool clientSessionTerminatedAbruptly = false, bool forceImmediate = false)
         {
-            if (PKLogoutActive && !forceImmediate || PkLogoutState != LogoutState.Pending)
+            if ((PKLogoutActive && !forceImmediate) || (PkLogoutState != LogoutState.Pending))
             {
                 return HandlePKLogout();
             }
@@ -605,7 +605,7 @@ namespace ACE.Server.WorldObjects
                 return false;
             }
 
-            if (Teleporting && MaterializedLogoutState is LogoutState.Pending)
+            if (Teleporting && !IsInDeathProcess && MaterializedLogoutState is LogoutState.Pending)
             {
                 ForceMaterializeForLogoff();
                 return false;

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -437,7 +437,7 @@ namespace ACE.Server.WorldObjects
                 });
 
                 teleportChain.EnqueueChain();
-            }), force: true);
+            }));
         }
 
         public bool suicideInProgress;

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -1381,7 +1381,7 @@ namespace ACE.Server.WorldObjects
             }
 
             // play script?
-            player.Teleport(house.BootSpot.Location, force: true);
+            player.Teleport(house.BootSpot.Location);
 
             owner = allegianceHouse ? "the allegiance" : "your";
             Session.Network.EnqueueSend(new GameMessageSystemChat($"Booted {player.Name} from {owner} house.", ChatMessageType.Broadcast));
@@ -1434,7 +1434,7 @@ namespace ACE.Server.WorldObjects
                 {
                     if (!rootHouse.IsOpen || (rootHouse.HouseType != HouseType.Apartment && CurrentLandblock.HasDungeon))
                     {
-                        Teleport(rootHouse.BootSpot.Location, force: true);
+                        Teleport(rootHouse.BootSpot.Location);
                         return true;
                     }
                 }

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -30,7 +30,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         /// <param name="positionType">PositionType to be teleported to</param>
         /// <returns>true on success (position is set) false otherwise</returns>
-        public bool TeleToPosition(PositionType positionType)
+        public bool TeleToPosition(PositionType positionType, bool force = true)
         {
             var position = GetPosition(positionType);
 
@@ -39,7 +39,7 @@ namespace ACE.Server.WorldObjects
                 var teleportDest = new Position(position);
                 AdjustDungeon(teleportDest);
 
-                Teleport(teleportDest);
+                Teleport(teleportDest, force);
                 return true;
             }
 
@@ -128,7 +128,7 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouHaveMovedTooFar));
                     return;
                 }
-                Teleport(house.SlumLord.Location);
+                Teleport(house.SlumLord.Location, force: false);
             });
 
             actionChain.EnqueueChain();
@@ -202,7 +202,7 @@ namespace ACE.Server.WorldObjects
                     return;
                 }
 
-                Teleport(Sanctuary);
+                Teleport(Sanctuary, force: false);
             });
 
             lifestoneChain.EnqueueChain();
@@ -268,7 +268,7 @@ namespace ACE.Server.WorldObjects
                     return;
                 }
 
-                Teleport(MarketplaceDrop);
+                Teleport(MarketplaceDrop, force: false);
             });
 
             // Set the chain to run
@@ -344,7 +344,7 @@ namespace ACE.Server.WorldObjects
                 if (!VerifyRecallAllegianceHometown())
                     return;
 
-                Teleport(Allegiance.Sanctuary);
+                Teleport(Allegiance.Sanctuary, force: false);
             });
 
             actionChain.EnqueueChain();
@@ -441,7 +441,7 @@ namespace ACE.Server.WorldObjects
                 if (allegianceHouse == null)
                     return;
 
-                Teleport(allegianceHouse.SlumLord.Location);
+                Teleport(allegianceHouse.SlumLord.Location, force: false);
             }); 
 
             actionChain.EnqueueChain();
@@ -560,7 +560,7 @@ namespace ACE.Server.WorldObjects
                 var rng = ThreadSafeRandom.Next(0, pkArenaLocs.Count - 1);
                 var loc = pkArenaLocs[rng];
 
-                Teleport(loc);
+                Teleport(loc, force: false);
             });
 
             actionChain.EnqueueChain();
@@ -644,7 +644,7 @@ namespace ACE.Server.WorldObjects
                 var rng = ThreadSafeRandom.Next(0, pklArenaLocs.Count - 1);
                 var loc = pklArenaLocs[rng];
 
-                Teleport(loc);
+                Teleport(loc, force: false);
             });
 
             actionChain.EnqueueChain();
@@ -670,40 +670,57 @@ namespace ACE.Server.WorldObjects
 
         public bool ForceTeleportMaterialization => PropertyManager.GetBool("force_teleport_materialization").Item;
 
-        public double TeleportMaterializedDuration => PropertyManager.GetDouble("force_teleport_materialization_duration").Item;
+        public double ForceTeleportMaterializationDuration => PropertyManager.GetDouble("force_teleport_materialization_duration").Item;
 
-        public bool BlockTeleportFromThreshold {
+        public bool IsRecentTeleportPreventionEnabled = PropertyManager.GetBool("recent_teleport_prevention").Item;
+
+        public bool BlockRecentTeleport {
             get
             {
+                if (!IsRecentTeleportPreventionEnabled)
+                    return false;
+
                 var secondsSinceMaterializing = Time.GetUnixTime() - LastTeleportEndTimestamp;
                 var RECENT_TELEPORT_THRESHOLD = PropertyManager.GetDouble("recent_teleport_threshold").Item;
                 return secondsSinceMaterializing < RECENT_TELEPORT_THRESHOLD;
             }
         }
 
+        public void ForceMaterializeForTeleport(ulong teleportId)
+        {
+            if (!ForceTeleportMaterialization)
+                return;
+
+            // if we are dead and teleporting, use normal teleport flow
+            if (IsInDeathProcess)
+                return;
+
+            var actionChain = new ActionChain();
+            actionChain.AddDelaySeconds(ForceTeleportMaterializationDuration);
+            actionChain.AddAction(this, () =>  OnTeleportComplete(teleportId));
+            actionChain.EnqueueChain();
+        }
+
+        /// <summary>
+        /// This is a teleport instance id guard, this prevents overlapping async action calls to force materialize. We only want one OnTeleportComplete to call per teleport
+        /// </summary>
+        private ulong _teleportId = 0;
+        public ulong CurrentTeleportId => _teleportId;
+
         /// <summary>
         /// This is not thread-safe. Consider using WorldManager.ThreadSafeTeleport() instead if you're calling this from a multi-threaded subsection.
         /// </summary>
-        public void Teleport(Position _newPosition, bool fromPortal = false, bool force = false)
+        public void Teleport(Position _newPosition, bool fromPortal = false, bool force = true)
         {
             if(!ValidateTeleport(_newPosition, force))
             {
-                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouHaveBeenTeleportedTooRecently));
                 return;
             }
 
             var newPosition = new Position(_newPosition);
             //newPosition.PositionZ += 0.005f;
             newPosition.PositionZ += 0.005f * (ObjScale ?? 1.0f);
-
-            // Force a materialization when teleporting
-            if (ForceTeleportMaterialization)
-            {
-                var actionChain = new ActionChain();
-                actionChain.AddDelaySeconds(TeleportMaterializedDuration);
-                actionChain.AddAction(this, OnTeleportComplete);
-                actionChain.EnqueueChain();
-            }
 
             //Console.WriteLine($"{Name}.Teleport() - Sending to {newPosition.ToLOCString()}");
 
@@ -714,19 +731,22 @@ namespace ACE.Server.WorldObjects
 
             if (currentFogColor.HasValue && currentFogColor != EnvironChangeType.Clear && !LandblockManager.GlobalFogColor.HasValue)
             {
-                var delayTelport = new ActionChain();
-                delayTelport.AddAction(this, () => ClearFogColor());
-                delayTelport.AddDelaySeconds(1);
-                delayTelport.AddAction(this, () => WorldManager.ThreadSafeTeleport(this, _newPosition, force: true));
+                var delayTeleport = new ActionChain();
+                delayTeleport.AddAction(this, () => ClearFogColor());
+                delayTeleport.AddDelaySeconds(1);
+                delayTeleport.AddAction(this, () => WorldManager.ThreadSafeTeleport(this, _newPosition));
 
-                delayTelport.EnqueueChain();
+                delayTeleport.EnqueueChain();
 
                 return;
             }
 
+            var currentTeleportId = ++_teleportId;
+
             Teleporting = true;
             LastTeleportTime = DateTime.UtcNow;
             LastTeleportStartTimestamp = Time.GetUnixTime();
+            OnTeleportCompleteFailureRetry = 0;
 
             if (fromPortal)
                 LastPortalTeleportTimestamp = LastTeleportStartTimestamp;
@@ -799,7 +819,7 @@ namespace ACE.Server.WorldObjects
                                 QuestManager.Erase("EnterBattleDungeon");
                             }
 
-                            Teleport(Sanctuary, force: true);
+                            Teleport(Sanctuary);
                             return;
                         }
 
@@ -808,7 +828,7 @@ namespace ACE.Server.WorldObjects
                         {
                             this.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have attempted to enter a zerg restricted area.  This area is currently only open to clans who are whitelisted for town control to prevent players from breaking allegiance in order to exceed clan capacity restrictions.  Please contact an admin to get your clan whitelisted for entry.", ChatMessageType.Broadcast));
 
-                            Teleport(Sanctuary, force: true);
+                            Teleport(Sanctuary);
                             return;
                         }
 
@@ -822,7 +842,7 @@ namespace ACE.Server.WorldObjects
                             {
                                 this.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your allegiance has already reached it's maximum number of entrants to this World Boss event. ", ChatMessageType.Broadcast));
 
-                                Teleport(Sanctuary, force: true);
+                                Teleport(Sanctuary);
                                 return;
                             }
                             else
@@ -843,7 +863,7 @@ namespace ACE.Server.WorldObjects
                         //The player has no allegiance, disallow entry
                         this.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have attempted to enter a zerg restricted area.  Unfortunately you are not a member of an allegiance and are unable to enter this area to prevent abuse by players who break allegiance to exceed the clan capacity limitations.  You have been redirected to your lifestone.", ChatMessageType.Broadcast));
 
-                        Teleport(Sanctuary, force: true);
+                        Teleport(Sanctuary);
                         return;
                     }
                 }
@@ -871,10 +891,16 @@ namespace ACE.Server.WorldObjects
             {
                 ArenaManager.ExitArenaObserverMode(this);
             }            
+
+            // Force a materialization when teleporting
+            ForceMaterializeForTeleport(currentTeleportId);
         }
 
         private bool ValidateTeleport(Position newPosition, bool force)
         {
+            if (!IsRecentTeleportPreventionEnabled)
+                return true;
+
             if (force)
                 return true;
 
@@ -883,7 +909,7 @@ namespace ACE.Server.WorldObjects
                 return false;
 
             // prevent teleporting after exiting portal space if it's within the recent teleport 
-            if (BlockTeleportFromThreshold)
+            if (BlockRecentTeleport)
                 return false;
 
             return true;
@@ -891,7 +917,7 @@ namespace ACE.Server.WorldObjects
 
         public void DoPreTeleportHide()
         {
-            if (Teleporting || BlockTeleportFromThreshold) return;
+            if (Teleporting || BlockRecentTeleport) return;
             PlayParticleEffect(PlayScript.Hide, Guid);
         }
 
@@ -919,8 +945,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public double? LastPortalTeleportTimestampError;
 
-        public void OnTeleportComplete()
+        private uint OnTeleportCompleteFailureRetry = 0;
+
+        public void OnTeleportComplete(ulong teleportId)
         {
+            if (teleportId != _teleportId)
+                return;
+
             if (!Teleporting)
                 return;
 
@@ -930,7 +961,7 @@ namespace ACE.Server.WorldObjects
                 // We'll check periodically to see when it's safe to let them materialize in
                 var actionChain = new ActionChain();
                 actionChain.AddDelaySeconds(0.1);
-                actionChain.AddAction(this, OnTeleportComplete);
+                actionChain.AddAction(this, () => OnTeleportComplete(teleportId));
                 actionChain.EnqueueChain();
                 return;
             }
@@ -940,13 +971,62 @@ namespace ACE.Server.WorldObjects
             //If player hasn't been in the portal for at least 3 seconds before exiting
             if (LastTeleportStartTimestamp > Time.GetUnixTime(DateTime.UtcNow.AddSeconds(-1*minPortalspaceSeconds)))
             {
-                var delayTelport = new ActionChain();
-                delayTelport.AddDelaySeconds(1);
-                delayTelport.AddAction(this, OnTeleportComplete);
-                delayTelport.EnqueueChain();
+                var delayTeleport = new ActionChain();
+                delayTeleport.AddDelaySeconds(1);
+                delayTeleport.AddAction(this, () => OnTeleportComplete(teleportId));
+                delayTeleport.EnqueueChain();
                 return;
             }
-            
+
+            // Update our location to wherever the physics says we ended up. This takes care of slightly invalid destination locations that both the server and client physics will autocorrect.
+            var physicsPos = PhysicsObj.Position;
+            var newPos = physicsPos.ACEPosition();
+
+            // If validating physics-derived position fails, log a warning and attempt to use the Sanctuary position as a fallback if not logging out, otherwise just exit.
+            if (physicsPos.ObjCellID == 0)
+            {
+                log.Warn($"[TELEPORT BLOCKED] Invalid ACE position for {Name}");
+                log.Warn($"  PhysicsObjCellID: {physicsPos.ObjCellID}");
+                log.Warn($"  PhysicsCell: {newPos.Cell}");
+                log.Warn($"  PhysicsPos: {newPos.Pos}");
+                log.Warn($"  CurrentPosCell: {Location.Cell}");
+                log.Warn($"  CurrentPos: {Location.Pos}");
+                log.Warn($"  Teleporting: {Teleporting}");
+                log.Warn($"  IsDeath: {IsInDeathProcess}");
+                log.Warn($"  LoggingOut: {IsLoggingOut}");
+
+                if (IsLoggingOut)
+                {
+                    Teleporting = false;
+                    OnTeleportCompleteFailureRetry = 0;
+
+                    var msg = $"{Name} is logging out while teleporting and ended up with invalid position data.";
+                    log.Warn(msg);
+                    SendMessage(msg, ChatMessageType.System);
+                    return;
+                }
+
+                // If we've exhausted retries to get a valid position, teleport the player to their sancutary as a last resort
+                if (OnTeleportCompleteFailureRetry >= 3)
+                {
+                    var fixLoc = Sanctuary ?? Instantiation ?? new Position(0xA9B40019, 84, 7.1f, 94, 0, 0, -0.0784591f, 0.996917f);
+                    var delayTeleport = new ActionChain();
+                    delayTeleport.AddDelaySeconds(1);
+                    delayTeleport.AddAction(this, () => WorldManager.ThreadSafeTeleport(this, fixLoc));
+                    delayTeleport.EnqueueChain();
+                    OnTeleportCompleteFailureRetry = 0;
+                    return;
+                } else
+                {
+                    var actionChain = new ActionChain();
+                    actionChain.AddDelaySeconds(0.5);
+                    actionChain.AddAction(this, () => OnTeleportComplete(teleportId));
+                    actionChain.EnqueueChain();
+                    OnTeleportCompleteFailureRetry++;
+                    return;
+                }
+            }
+
             // set materialize physics state
             // this takes the player from pink bubbles -> fully materialized
             if (CloakStatus != CloakStatus.On)
@@ -955,18 +1035,20 @@ namespace ACE.Server.WorldObjects
             IgnoreCollisions = false;
             Hidden = false;
             Teleporting = false;
-            Location = PhysicsObj.Position.ACEPosition(); // Update our location to wherever the physics says we ended up. This takes care of slightly invalid destination locations that both the server and client physics will autocorrect.
+
+
             SnapPos = Location;
             PrevMovementUpdateMaxSpeed = 0.0f;
             LastPlayerInitiatedActionTime = DateTime.UtcNow;
-
+            Location = newPos; 
             LastPlayerMovementCheckTime = DateTime.UtcNow;
             HasPerformedActionsSinceLastMovementUpdate = false;
+            OnTeleportCompleteFailureRetry = 0;
 
             CheckMonsters();
             CheckHouse();
             CheckVisibleBounties();
-
+            CheckMaterializedLogoutState();
             EnqueueBroadcastPhysicsState();
 
             // hijacking this for both start/end on portal teleport
@@ -977,8 +1059,25 @@ namespace ACE.Server.WorldObjects
             LastTeleportEndTimestamp = Time.GetUnixTime();
         }
 
+        private void CheckMaterializedLogoutState()
+        {
+            // If a character is stuck in a materialized progress state after materializing, try to add them to logoff queue to get them unstuck.
+            if (MaterializedLogoutState == LogoutState.InProgress)
+            {
+                MaterializedLogoutState = LogoutState.Ready;
+                if (!PlayerManager.IsInLogoffQueue(this))
+                {
+                    LogoffTimestamp = Time.GetUnixTime();
+                    PlayerManager.AddPlayerToLogoffQueue(this);
+                }
+            }
+        }
+
         public void SendTeleportedViaMagicMessage(WorldObject itemCaster, Spell spell)
         {
+            if (BlockRecentTeleport)
+                return;
+
             if (itemCaster == null || itemCaster is Gem)
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"You have been teleported.", ChatMessageType.Magic));
             else if (this != itemCaster && !(itemCaster is Gem) && !(itemCaster is Switch) && !(itemCaster.GetProperty(PropertyBool.NpcInteractsSilently) ?? false))

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -707,15 +707,28 @@ namespace ACE.Server.WorldObjects
         private ulong _teleportId = 0;
         public ulong CurrentTeleportId => _teleportId;
 
+        public Position FallbackPosition => Sanctuary ?? Instantiation ?? new Position(0xA9B40019, 84, 7.1f, 94, 0, 0, -0.0784591f, 0.996917f);
+
         /// <summary>
         /// This is not thread-safe. Consider using WorldManager.ThreadSafeTeleport() instead if you're calling this from a multi-threaded subsection.
         /// </summary>
         public void Teleport(Position _newPosition, bool fromPortal = false, bool force = true)
         {
-            if(!ValidateTeleport(_newPosition, force))
+            var validateResult = ValidateTeleport(_newPosition, force);
+
+            switch (validateResult)
             {
-                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouHaveBeenTeleportedTooRecently));
-                return;
+                case TeleportValidationResult.Allowed:
+                    break;
+
+                case TeleportValidationResult.BlockedRecentTeleport:
+                    Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouHaveBeenTeleportedTooRecently));
+                    return;
+
+                case TeleportValidationResult.InvalidDestination:
+                    WorldManager.ThreadSafeTeleport(this, new Position(FallbackPosition));
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("The location you have been teleported to was invalid, you have been moved to a safe location instead.", ChatMessageType.System));
+                    return;
             }
 
             var newPosition = new Position(_newPosition);
@@ -896,23 +909,31 @@ namespace ACE.Server.WorldObjects
             ForceMaterializeForTeleport(currentTeleportId);
         }
 
-        private bool ValidateTeleport(Position newPosition, bool force)
+        private enum TeleportValidationResult
         {
-            if (!IsRecentTeleportPreventionEnabled)
-                return true;
+            Allowed,
+            BlockedRecentTeleport,
+            InvalidDestination
+        }
 
-            if (force)
-                return true;
+        private TeleportValidationResult ValidateTeleport(Position newPosition, bool force)
+        {
+            if (IsAdmin)
+                return TeleportValidationResult.Allowed;
 
-            // prevent teleporting if already teleporting 
+            if (!newPosition.IsValidPosition())
+                return TeleportValidationResult.InvalidDestination;
+
+            if (!IsRecentTeleportPreventionEnabled || force)
+                return TeleportValidationResult.Allowed;
+
             if (Teleporting)
-                return false;
+                return TeleportValidationResult.BlockedRecentTeleport;
 
-            // prevent teleporting after exiting portal space if it's within the recent teleport 
             if (BlockRecentTeleport)
-                return false;
+                return TeleportValidationResult.BlockedRecentTeleport;
 
-            return true;
+            return TeleportValidationResult.Allowed;
         }
 
         public void DoPreTeleportHide()
@@ -983,12 +1004,13 @@ namespace ACE.Server.WorldObjects
             var newPos = physicsPos.ACEPosition();
 
             // If validating physics-derived position fails, log a warning and attempt to use the Sanctuary position as a fallback if not logging out, otherwise just exit.
-            if (physicsPos.ObjCellID == 0)
+            if (physicsPos.ObjCellID == 0 || physicsPos.Landblock == 0 || !newPos.IsValidPosition())
             {
                 log.Warn($"[TELEPORT BLOCKED] Invalid ACE position for {Name}");
                 log.Warn($"  PhysicsObjCellID: {physicsPos.ObjCellID}");
+                log.Warn($"  PhysicsLandblock: {physicsPos.Landblock}");
                 log.Warn($"  PhysicsCell: {newPos.Cell}");
-                log.Warn($"  PhysicsPos: {newPos.Pos}");
+                log.Warn($"  CurrentPosLandblock: {newPos.Landblock}");
                 log.Warn($"  CurrentPosCell: {Location.Cell}");
                 log.Warn($"  CurrentPos: {Location.Pos}");
                 log.Warn($"  Teleporting: {Teleporting}");
@@ -1009,20 +1031,21 @@ namespace ACE.Server.WorldObjects
                 // If we've exhausted retries to get a valid position, teleport the player to their sancutary as a last resort
                 if (OnTeleportCompleteFailureRetry >= 3)
                 {
-                    var fixLoc = Sanctuary ?? Instantiation ?? new Position(0xA9B40019, 84, 7.1f, 94, 0, 0, -0.0784591f, 0.996917f);
+                    log.Warn("Failed to get valid position after multiple retries, teleporting to sanctuary as fallback.");
+                    var fallbackPosition = new Position(FallbackPosition);
                     var delayTeleport = new ActionChain();
-                    delayTeleport.AddDelaySeconds(1);
-                    delayTeleport.AddAction(this, () => WorldManager.ThreadSafeTeleport(this, fixLoc));
+                    delayTeleport.AddAction(this, () => Teleport(fallbackPosition));
                     delayTeleport.EnqueueChain();
                     OnTeleportCompleteFailureRetry = 0;
                     return;
                 } else
                 {
+                    OnTeleportCompleteFailureRetry++;
+                    log.Warn($"  Failed to get valid position, retrying after short delay. Retry count: {OnTeleportCompleteFailureRetry}");
                     var actionChain = new ActionChain();
-                    actionChain.AddDelaySeconds(0.5);
+                    actionChain.AddDelaySeconds(0.1);
                     actionChain.AddAction(this, () => OnTeleportComplete(teleportId));
                     actionChain.EnqueueChain();
-                    OnTeleportCompleteFailureRetry++;
                     return;
                 }
             }

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -143,6 +143,8 @@ namespace ACE.Server.WorldObjects
                 actionChain.EnqueueChain();
             }
 
+            ForceMaterializeForLogin();
+
             log.DebugFormat("[LOGIN] Account {0} entered the world with character {1} (0x{2}) at {3}.", Account.AccountName, Name, Guid, DateTime.Now.ToCommonString());
         }
 
@@ -512,6 +514,22 @@ namespace ACE.Server.WorldObjects
             }
 
             return false;
+        }
+        public bool ForceLoginMaterialization => PropertyManager.GetBool("force_login_materialization").Item;
+        public double ForceLoginMaterializationDuration => PropertyManager.GetDouble("force_login_materialization_duration").Item;
+        public void ForceMaterializeForLogin()
+        {
+            if (!ForceLoginMaterialization)
+                return;
+
+            // if we are dead and teleporting, exit
+            if (IsInDeathProcess)
+                return;
+
+            var actionChain = new ActionChain();
+            actionChain.AddDelaySeconds(ForceLoginMaterializationDuration);
+            actionChain.AddAction(this, () => OnTeleportComplete(CurrentTeleportId));
+            actionChain.EnqueueChain();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -331,7 +331,7 @@ namespace ACE.Server.WorldObjects
 
                 player.SendWeenieError(WeenieError.ITeleported);
 
-            }), true);
+            }), force: false);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1192,7 +1192,7 @@ namespace ACE.Server.WorldObjects
                     ActionChain lifestoneRecall = new ActionChain();
                     lifestoneRecall.AddAction(targetPlayer, () => targetPlayer.DoPreTeleportHide());
                     lifestoneRecall.AddDelaySeconds(2.0f);  // 2 second delay
-                    lifestoneRecall.AddAction(targetPlayer, () => targetPlayer.TeleToPosition(recall));
+                    lifestoneRecall.AddAction(targetPlayer, () => targetPlayer.TeleToPosition(recall, force: false));
                     lifestoneRecall.EnqueueChain();
                 }
                 else
@@ -1223,7 +1223,7 @@ namespace ACE.Server.WorldObjects
                         var teleportDest = new Position(portal.Destination);
                         AdjustDungeon(teleportDest);
 
-                        targetPlayer.Teleport(teleportDest);
+                        targetPlayer.Teleport(teleportDest, force: false);
                     });
                     portalRecall.EnqueueChain();
                 }
@@ -1381,7 +1381,7 @@ namespace ACE.Server.WorldObjects
                     var teleportDest = new Position(spell.Position);
                     AdjustDungeon(teleportDest);
 
-                    targetPlayer.Teleport(teleportDest);
+                    targetPlayer.Teleport(teleportDest, force: false);
 
                     targetPlayer.SendTeleportedViaMagicMessage(itemCaster, spell);
                 });
@@ -1434,7 +1434,7 @@ namespace ACE.Server.WorldObjects
                 var teleportDest = new Position(spell.Position);
                 AdjustDungeon(teleportDest);
 
-                targetPlayer.Teleport(teleportDest);
+                targetPlayer.Teleport(teleportDest, force: false);
 
                 targetPlayer.SendTeleportedViaMagicMessage(itemCaster, spell);
             });


### PR DESCRIPTION


- add StuckCharacterLog table to track metadata for characters using /ForceLogoffStuckCharacter
- add validation and retry logic for invalid physics positions during OnTeleportComplete
- introduce teleportId guard to prevent duplicate async OnTeleportComplete calls
- separate force login materialization logic and add related server properties
- make force teleport the default behavior
- add "recent_teleport_prevention" toggle for teleport safeguards