### PR TITLE
T9 Balance Tweaks

### DIFF
--- a/Content/sql/landblocks/0105.sql
+++ b/Content/sql/landblocks/0105.sql
@@ -129,7 +129,7 @@ VALUES (0x70105021, 451601629, 0x01050150, 49.8087, -202.788, -23.989, 0.007625,
 /* @teleloc 0x01050150 [49.808701 -202.787994 -23.989000] 0.007625 0.000000 0.000000 0.999971 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70105022,  3955, 0x01050154, 49.3402, -209.248, -23.995, 0.999956, 0, 0, 0.009417, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (15 min.) */
+VALUES (0x70105022,  7932, 0x01050154, 49.3402, -209.248, -23.995, 0.999956, 0, 0, 0.009417, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (4 min.) */
 /* @teleloc 0x01050154 [49.340199 -209.248001 -23.995001] 0.999956 0.000000 0.000000 0.009417 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -490,14 +490,14 @@ VALUES (0x70105079, 451601628, 0x01050377, 109.603, -140.554, 0.011, 0.027645, 0
 /* @teleloc 0x01050377 [109.602997 -140.554001 0.011000] 0.027645 0.000000 0.000000 0.999618 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7010507A,  3955, 0x01050382, 110.001, -210.013, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (15 min.) */
+VALUES (0x7010507A,  7932, 0x01050382, 110.001, -210.013, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (4 min.) */
 /* @teleloc 0x01050382 [110.000999 -210.013000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7010507A, 0x70105067, '2005-02-09 10:00:00');
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7010507B,  3955, 0x01050382, 110.179, -208.522, 0.005, 0.999792, 0, 0, 0.020411, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (15 min.) */
+VALUES (0x7010507B,  7932, 0x01050382, 110.179, -208.522, 0.005, 0.999792, 0, 0, 0.020411, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (4 min.) */
 /* @teleloc 0x01050382 [110.179001 -208.522003 0.005000] 0.999792 0.000000 0.000000 0.020411 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Content/sql/weenies/T9Dungeons/408590 T9 Great Work.sql
+++ b/Content/sql/weenies/T9Dungeons/408590 T9 Great Work.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 408590;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (408590, 'ace408590-greatwork', 10, '2026-04-29 10:29:23') /* Creature */;
+VALUES (408590, 'ace408590-greatwork', 10, '2026-04-30 08:05:57') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (408590,   1,         16) /* ItemType - Creature */
@@ -15,9 +15,9 @@ VALUES (408590,   1,         16) /* ItemType - Creature */
      , (408590,  81,          6) /* MaxGeneratedObjects */
      , (408590,  82,          6) /* InitGeneratedObjects */
      , (408590,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
-     , (408590, 307,        100) /* DamageRating */
      , (408590, 103,          3) /* GeneratorDestructionType - Kill */
-     , (408590, 133,          4) /* ShowableOnRadar - ShowAlways */;
+     , (408590, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (408590, 307,        100) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (408590,   1, True ) /* Stuck */
@@ -47,7 +47,7 @@ VALUES (408590,   1,       5) /* HeartbeatInterval */
      , (408590,  43,      10) /* GeneratorRadius */
      , (408590,  64,    0.75) /* ResistSlash */
      , (408590,  65,    0.75) /* ResistPierce */
-     , (408590,  66,    0.75) /* ResistBludgeon */
+     , (408590,  66,       1) /* ResistBludgeon */
      , (408590,  67,     0.3) /* ResistFire */
      , (408590,  68,     0.3) /* ResistCold */
      , (408590,  69,     0.3) /* ResistAcid */
@@ -81,27 +81,27 @@ VALUES (408590,   1,4800, 0, 0) /* Strength */
      , (408590,   6,1200, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (408590,   1,149600, 0, 0,150000) /* MaxHealth */
-     , (408590,   3, 10000, 0, 0,10100) /* MaxStamina */
-     , (408590,   5, 30000, 0, 0,30600) /* MaxMana */;
+VALUES (408590,   1,169600, 0, 0,170000) /* MaxHealth */
+     , (408590,   3,  9300, 0, 0,10100) /* MaxStamina */
+     , (408590,   5, 29400, 0, 0,30600) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (408590,  6, 0, 3, 0, 292, 0, 0) /* MeleeDefense         Specialized */
-     , (408590,  7, 0, 3, 0, 485, 0, 0) /* MissileDefense       Specialized */
-     , (408590, 15, 0, 3, 0, 133, 0, 0) /* MagicDefense         Specialized */
+VALUES (408590,  6, 0, 2, 0, 292, 0, 0) /* MeleeDefense             Trained */
+     , (408590,  7, 0, 2, 0, 485, 0, 0) /* MissileDefense           Trained */
+     , (408590, 15, 0, 2, 0, 133, 0, 0) /* MagicDefense             Trained */
      , (408590, 34, 0, 3, 0, 150, 0, 0) /* WarMagic             Specialized */
      , (408590, 45, 0, 3, 0, 180, 0, 0) /* LightWeapons         Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (408590,  0,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (408590,  1,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (408590,  2,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (408590,  3,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (408590,  4,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (408590,  5,  4,  1, 0.75,  250,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (408590,  6,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (408590,  7,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (408590,  8,  4,  1, 0.75,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (408590,  0,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (408590,  1,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (408590,  2,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (408590,  3,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (408590,  4,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (408590,  5,  4,  1, 0.75,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (408590,  6,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (408590,  7,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (408590,  8,  4,  1, 0.75,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (408590,  4423,   2.23) /* Incantation of Flame Arc */
@@ -116,15 +116,15 @@ VALUES (408590,  4423,   2.23) /* Incantation of Flame Arc */
      , (408590,  4643,      3) /* Incantation of Drain Health Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
-     , (408590, 9, 361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */;
+VALUES (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */
+     , (408590, 9,361849,  0, 0,    1, False) /* Create Great Work Shard (408590) for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (408590, -1, 4085901, 30, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Great Work Satellite (4085901) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */

--- a/Content/sql/weenies/T9Dungeons/4085901 T9 Great Work Satellite.sql
+++ b/Content/sql/weenies/T9Dungeons/4085901 T9 Great Work Satellite.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 4085901;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (4085901, 'ace4085901-gwsatellite', 10, '2026-04-29 10:29:21') /* Creature */;
+VALUES (4085901, 'ace4085901-gwsatellite', 10, '2026-04-30 08:04:32') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (4085901,   1,         16) /* ItemType - Creature */
@@ -16,9 +16,9 @@ VALUES (4085901,   1,         16) /* ItemType - Creature */
      , (4085901,  81,          4) /* MaxGeneratedObjects */
      , (4085901,  82,          4) /* InitGeneratedObjects */
      , (4085901,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
-     , (4085901, 307,        50) /* DamageRating */
      , (4085901, 103,          3) /* GeneratorDestructionType - Kill */
-     , (4085901, 133,          4) /* ShowableOnRadar - ShowAlways */;
+     , (4085901, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (4085901, 307,         80) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (4085901,   1, True ) /* Stuck */
@@ -48,7 +48,7 @@ VALUES (4085901,   1,       5) /* HeartbeatInterval */
      , (4085901,  43,      15) /* GeneratorRadius */
      , (4085901,  64,    0.75) /* ResistSlash */
      , (4085901,  65,    0.75) /* ResistPierce */
-     , (4085901,  66,    0.75) /* ResistBludgeon */
+     , (4085901,  66,       1) /* ResistBludgeon */
      , (4085901,  67,     0.3) /* ResistFire */
      , (4085901,  68,     0.3) /* ResistCold */
      , (4085901,  69,     0.3) /* ResistAcid */
@@ -83,27 +83,27 @@ VALUES (4085901,   1, 800, 0, 0) /* Strength */
      , (4085901,   6, 600, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (4085901,   1,   5000, 0, 0, 5000) /* MaxHealth */
+VALUES (4085901,   1,  5000, 0, 0, 5000) /* MaxHealth */
      , (4085901,   3,  1000, 0, 0, 1100) /* MaxStamina */
      , (4085901,   5, 30000, 0, 0,30600) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (4085901,  6, 0, 3, 0, 292, 0, 0) /* MeleeDefense         Specialized */
-     , (4085901,  7, 0, 3, 0, 485, 0, 0) /* MissileDefense       Specialized */
-     , (4085901, 15, 0, 3, 0, 304, 0, 0) /* MagicDefense         Specialized */
+VALUES (4085901,  6, 0, 2, 0, 292, 0, 0) /* MeleeDefense             Trained */
+     , (4085901,  7, 0, 2, 0, 485, 0, 0) /* MissileDefense           Trained */
+     , (4085901, 15, 0, 2, 0, 304, 0, 0) /* MagicDefense             Trained */
      , (4085901, 34, 0, 3, 0, 250, 0, 0) /* WarMagic             Specialized */
      , (4085901, 45, 0, 3, 0, 180, 0, 0) /* LightWeapons         Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (4085901,  0,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (4085901,  1,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (4085901,  2,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (4085901,  3,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (4085901,  4,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (4085901,  5,  4,  1, 0.75,  200,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (4085901,  6,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (4085901,  7,  4,  0,    0,  200,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (4085901,  8,  4,  1, 0.75,  200,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (4085901,  0,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (4085901,  1,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (4085901,  2,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (4085901,  3,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (4085901,  4,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (4085901,  5,  4,  1, 0.75,  180,  180,  180,  180,  180,  180,  180,  180,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (4085901,  6,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (4085901,  7,  4,  0,    0,  180,  180,  180,  180,  180,  180,  180,  180,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (4085901,  8,  4,  1, 0.75,  180,  180,  180,  180,  180,  180,  180,  180,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (4085901,  4421,   2.25) /* Incantation of Acid Arc */

--- a/Content/sql/weenies/T9Dungeons/451600023 Virindi Servant.sql
+++ b/Content/sql/weenies/T9Dungeons/451600023 Virindi Servant.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600023;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600023, 'T9_virindi', 10, '2026-04-06 08:18:33') /* Creature */;
+VALUES (451600023, 'T9_virindi', 10, '2026-04-30 06:24:14') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600023,   1,         16) /* ItemType - Creature */
@@ -18,8 +18,8 @@ VALUES (451600023,   1,         16) /* ItemType - Creature */
      , (451600023, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451600023, 140,          1) /* AiOptions - CanOpenDoors */
      , (451600023, 146,   50000000) /* XpOverride */
-     , (451600023, 307,        110) /* DamageRating */
-     , (451600023, 308,         35) /* DamageResistRating */
+     , (451600023, 307,        75) /* DamageRating */
+     , (451600023, 308,         30) /* DamageResistRating */
      , (451600023, 332,       6250) /* LuminanceAward */
      , (451600023, 386,         15) /* Overpower */;
 
@@ -43,7 +43,7 @@ VALUES (451600023,   1,       5) /* HeartbeatInterval */
      , (451600023,  14,       1) /* ArmorModVsPierce */
      , (451600023,  15,       1) /* ArmorModVsBludgeon */
      , (451600023,  16,    0.72) /* ArmorModVsCold */
-     , (451600023,  17,       1) /* ArmorModVsFire */
+     , (451600023,  17,    0.75) /* ArmorModVsFire */
      , (451600023,  18,       1) /* ArmorModVsAcid */
      , (451600023,  19,    0.72) /* ArmorModVsElectric */
      , (451600023,  31,      16) /* VisualAwarenessRange */
@@ -82,39 +82,39 @@ VALUES (451600023,   1, 0x02000041) /* Setup */
      , (451600023,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451600023,   1,10000, 0, 0) /* Strength */
-     , (451600023,   2,2150, 0, 0) /* Endurance */
+VALUES (451600023,   1,1300, 0, 0) /* Strength */
+     , (451600023,   2,1500, 0, 0) /* Endurance */
      , (451600023,   3, 850, 0, 0) /* Quickness */
      , (451600023,   4,1200, 0, 0) /* Coordination */
      , (451600023,   5,1250, 0, 0) /* Focus */
      , (451600023,   6, 650, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600023,   1, 18000, 0, 0,15000) /* MaxHealth */
-     , (451600023,   3, 15000, 0, 0,15000) /* MaxStamina */
-     , (451600023,   5, 15000, 0, 0,15000) /* MaxMana */;
+VALUES (451600023,   1, 14250, 0, 0,15000) /* MaxHealth */
+     , (451600023,   3,   500, 0, 0, 2000) /* MaxStamina */
+     , (451600023,   5,  2350, 0, 0, 3000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600023,  6, 0, 3, 0,   0, 0, 0) /* MeleeDefense        Specialized */
-     , (451600023,  7, 0, 3, 0, 190, 0, 0) /* MissileDefense      Specialized */
+VALUES (451600023,  6, 0, 2, 0,  52, 0, 0) /* MeleeDefense             Trained */
+     , (451600023,  7, 0, 2, 0, 340, 0, 0) /* MissileDefense           Trained */
      , (451600023, 14, 0, 2, 0, 190, 0, 0) /* ArcaneLore          Trained */
-     , (451600023, 15, 0, 3, 0, 250, 0, 0) /* MagicDefense        Specialized */
+     , (451600023, 15, 0, 3, 0, 229, 0, 0) /* MagicDefense         Specialized */
      , (451600023, 20, 0, 2, 0, 250, 0, 0) /* Deception           Trained */
      , (451600023, 24, 0, 2, 0, 980, 0, 0) /* Run                 Trained */
      , (451600023, 31, 0, 3, 0, 935, 0, 0) /* CreatureEnchantment Specialized */
      , (451600023, 33, 0, 3, 0, 935, 0, 0) /* LifeMagic           Specialized */
      , (451600023, 34, 0, 3, 0,1835, 0, 0) /* WarMagic            Specialized */
-     , (451600023, 45, 0, 3, 0,4850, 0, 0) /* LightWeapons        Specialized */
-     , (451600023, 46, 0, 3, 0,4850, 0, 0) /* FinesseWeapons      Specialized */;
+     , (451600023, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons         Specialized */
+     , (451600023, 46, 0, 3, 0, 417, 0, 0) /* FinesseWeapons       Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451600023,  0,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (451600023,  1,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (451600023,  2,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen */
-     , (451600023,  3,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (451600023,  4,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm */
-     , (451600023,  5,  1, 15, 0.75,  300,  300,  300,  300,  220,  300,  300,  220,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (451600023, 17,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail */;
+VALUES (451600023,  0,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Slash */
+     , (451600023,  1,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Slash */
+     , (451600023,  2,  1,  0,    0,  300,  300,  300,  300,  220,  300,  220,  220,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen - Slash */
+     , (451600023,  3,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Slash */
+     , (451600023,  4,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm - Slash */
+     , (451600023,  5,  1, 20, 0.75,  300,  300,  300,  300,  220,  220,  300,  220,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Slash */
+     , (451600023, 17,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail - Slash */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451600023,  4433,   2.02) /* Incantation of Acid Stream */
@@ -125,7 +125,6 @@ VALUES (451600023,  4433,   2.02) /* Incantation of Acid Stream */
      , (451600023,  4457,   2.02) /* Incantation of Whirling Blade */
      , (451600023,  4434,   2.02) /* Incantation of Acid Volley */
      , (451600023,  4449,   2.02) /* Incantation of Frost Volley */
-     , (451600023,  3991,   2.06) /* Thaumic Bleed */
      , (451600023,  4441,   2.02) /* Incantation of Flame Volley */
      , (451600023,  4483,   2.05) /* Incantation of Lightning Vulnerability Other */
      , (451600023,  4475,   2.05) /* Incantation of Blade Vulnerability Other */
@@ -135,9 +134,9 @@ VALUES (451600023,  4433,   2.02) /* Incantation of Acid Stream */
      , (451600023,  4322,   2.02) /* Incantation of Slowness Other */;
 
 INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (451600023,  94)
-     , (451600023, 414);
-     
+VALUES (451600023,         94) /*  */
+     , (451600023,        414) /*  */;
+
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451600023, 3 /* Death */, 0.0125, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 

--- a/Content/sql/weenies/T9Dungeons/451600194 Copper Golem.sql
+++ b/Content/sql/weenies/T9Dungeons/451600194 Copper Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600194;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600194, 'T9_golemcopper', 10, '2026-04-06 08:18:09') /* Creature */;
+VALUES (451600194, 'T9_golemcopper', 10, '2026-04-30 07:18:48') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600194,   1,         16) /* ItemType - Creature */
@@ -19,8 +19,8 @@ VALUES (451600194,   1,         16) /* ItemType - Creature */
      , (451600194,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (451600194, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451600194, 146,   35000000) /* XpOverride */
-     , (451600194, 307,        125) /* DamageRating */
-     , (451600194, 308,         65) /* DamageResistRating */
+     , (451600194, 307,         75) /* DamageRating */
+     , (451600194, 308,         35) /* DamageResistRating */
      , (451600194, 332,       5000) /* LuminanceAward */
      , (451600194, 386,         35) /* Overpower */;
 
@@ -46,7 +46,7 @@ VALUES (451600194,   1,       5) /* HeartbeatInterval */
      , (451600194,  12,     0.5) /* Shade */
      , (451600194,  13,    0.44) /* ArmorModVsSlash */
      , (451600194,  14,    0.58) /* ArmorModVsPierce */
-     , (451600194,  15,    0.86) /* ArmorModVsBludgeon */
+     , (451600194,  15,     0.7) /* ArmorModVsBludgeon */
      , (451600194,  16,    0.33) /* ArmorModVsCold */
      , (451600194,  17,    0.33) /* ArmorModVsFire */
      , (451600194,  18,     0.8) /* ArmorModVsAcid */
@@ -56,7 +56,7 @@ VALUES (451600194,   1,       5) /* HeartbeatInterval */
      , (451600194,  43,       3) /* GeneratorRadius */
      , (451600194,  64,    0.33) /* ResistSlash */
      , (451600194,  65,     0.5) /* ResistPierce */
-     , (451600194,  66,    0.83) /* ResistBludgeon */
+     , (451600194,  66,       1) /* ResistBludgeon */
      , (451600194,  67,     0.2) /* ResistFire */
      , (451600194,  68,     0.2) /* ResistCold */
      , (451600194,  69,       1) /* ResistAcid */
@@ -68,7 +68,8 @@ VALUES (451600194,   1,       5) /* HeartbeatInterval */
      , (451600194,  75,       1) /* ResistManaBoost */
      , (451600194,  80,       3) /* AiUseMagicDelay */
      , (451600194, 104,      10) /* ObviousRadarRange */
-     , (451600194, 125,       1) /* ResistHealthDrain */;
+     , (451600194, 125,       1) /* ResistHealthDrain */
+     , (451600194, 151,       1) /* IgnoreShield */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (451600194,   1, 'Blood Guardian') /* Name */;
@@ -85,23 +86,23 @@ VALUES (451600194,   1, 0x020013F7) /* Setup */
      , (451600194,  35,      10021) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451600194,   1,5000, 0, 0) /* Strength */
-     , (451600194,   2,20000, 0, 0) /* Endurance */
+VALUES (451600194,   1,4000, 0, 0) /* Strength */
+     , (451600194,   2,2000, 0, 0) /* Endurance */
      , (451600194,   3, 500, 0, 0) /* Quickness */
      , (451600194,   4,1200, 0, 0) /* Coordination */
      , (451600194,   5,2200, 0, 0) /* Focus */
      , (451600194,   6,1200, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600194,   1, 22000, 0, 0,32000) /* MaxHealth */
-     , (451600194,   3,     0, 0, 0,20000) /* MaxStamina */
-     , (451600194,   5, 13600, 0, 0,15000) /* MaxMana */;
+VALUES (451600194,   1, 21000, 0, 0,22000) /* MaxHealth */
+     , (451600194,   3,   200, 0, 0, 2200) /* MaxStamina */
+     , (451600194,   5,   300, 0, 0, 1500) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600194,  6, 0, 3, 0, 214, 0, 0) /* MeleeDefense         Specialized */
-     , (451600194,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense       Specialized */
+VALUES (451600194,  6, 0, 2, 0, 204, 0, 0) /* MeleeDefense             Trained */
+     , (451600194,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense           Trained */
      , (451600194, 14, 0, 2, 0, 200, 0, 0) /* ArcaneLore          Trained */
-     , (451600194, 15, 0, 3, 0,  15, 0, 0) /* MagicDefense         Specialized */
+     , (451600194, 15, 0, 2, 0,   5, 0, 0) /* MagicDefense             Trained */
      , (451600194, 20, 0, 2, 0, 400, 0, 0) /* Deception                Trained */
      , (451600194, 22, 0, 2, 0,  10, 0, 0) /* Jump                Trained */
      , (451600194, 24, 0, 2, 0, 910, 0, 0) /* Run                 Trained */
@@ -122,11 +123,11 @@ VALUES (451600194,  0,  4,  0,    0,  300,  132,  176,  260,  100,  100,  240,  
      , (451600194,  8,  4, 50, 0.75,  300,  132,  176,  260,  100,  100,  240,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451600194,  4455,   2.09) /* Incantation of Shock Wave */
-     , (451600194,  4457,   2.09) /* Incantation of Whirling Blade */
-     , (451600194,  4454,   2.09) /* Incantation of Shock Blast */
-     , (451600194,  4633,  2.005) /* Incantation of Vulnerability Other */
-     , (451600194,  4643,   2.07) /* Incantation of Drain Health Other */;
+VALUES (451600194,  4455,   2.06) /* Incantation of Shock Wave */
+     , (451600194,  4457,   2.06) /* Incantation of Whirling Blade */
+     , (451600194,  4454,   2.02) /* Incantation of Shock Blast */
+     , (451600194,  4633,   2.01) /* Incantation of Vulnerability Other */
+     , (451600194,  4643,   2.05) /* Incantation of Drain Health Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451600194, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451600195 Granite Golem.sql
+++ b/Content/sql/weenies/T9Dungeons/451600195 Granite Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600195;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600195, 'T9_golemgranite', 10, '2026-04-06 08:17:52') /* Creature */;
+VALUES (451600195, 'T9_golemgranite', 10, '2026-04-30 07:22:47') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600195,   1,         16) /* ItemType - Creature */
@@ -19,8 +19,8 @@ VALUES (451600195,   1,         16) /* ItemType - Creature */
      , (451600195,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (451600195, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451600195, 146,   35000000) /* XpOverride */
-     , (451600195, 307,        100) /* DamageRating */
-     , (451600195, 308,         45) /* DamageResistRating */
+     , (451600195, 307,         65) /* DamageRating */
+     , (451600195, 308,         30) /* DamageResistRating */
      , (451600195, 332,       4000) /* LuminanceAward */
      , (451600195, 386,         25) /* Overpower */;
 
@@ -66,7 +66,8 @@ VALUES (451600195,   1,       5) /* HeartbeatInterval */
      , (451600195,  75,       1) /* ResistManaBoost */
      , (451600195,  80,     2.5) /* AiUseMagicDelay */
      , (451600195, 104,      10) /* ObviousRadarRange */
-     , (451600195, 125,       1) /* ResistHealthDrain */;
+     , (451600195, 125,       1) /* ResistHealthDrain */
+     , (451600195, 151,       1) /* IgnoreShield */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (451600195,   1, 'Sapphire Guardian') /* Name */;
@@ -83,47 +84,47 @@ VALUES (451600195,   1, 0x020007D7) /* Setup */
      , (451600195,  35,      10021) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451600195,   1,4000, 0, 0) /* Strength */
-     , (451600195,   2,20000, 0, 0) /* Endurance */
+VALUES (451600195,   1,3500, 0, 0) /* Strength */
+     , (451600195,   2,2000, 0, 0) /* Endurance */
      , (451600195,   3, 500, 0, 0) /* Quickness */
      , (451600195,   4,1200, 0, 0) /* Coordination */
      , (451600195,   5,2200, 0, 0) /* Focus */
      , (451600195,   6,1200, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600195,   1, 13000, 0, 0,28000) /* MaxHealth */
-     , (451600195,   3, 10000, 0, 0,30000) /* MaxStamina */
-     , (451600195,   5, 33860, 0, 0,34000) /* MaxMana */;
+VALUES (451600195,   1, 19000, 0, 0,20000) /* MaxHealth */
+     , (451600195,   3, 18000, 0, 0,20000) /* MaxStamina */
+     , (451600195,   5, 18800, 0, 0,20000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600195,  6, 0, 3, 0, 214, 0, 0) /* MeleeDefense         Specialized */
+VALUES (451600195,  6, 0, 2, 0, 209, 0, 0) /* MeleeDefense             Trained */
      , (451600195,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense       Specialized */
      , (451600195, 14, 0, 2, 0, 190, 0, 0) /* ArcaneLore          Trained */
-     , (451600195, 15, 0, 3, 0,  15, 0, 0) /* MagicDefense         Specialized */
+     , (451600195, 15, 0, 2, 0,   0, 0, 0) /* MagicDefense             Trained */
      , (451600195, 20, 0, 2, 0, 400, 0, 0) /* Deception                Trained */
      , (451600195, 22, 0, 2, 0,  10, 0, 0) /* Jump                Trained */
      , (451600195, 24, 0, 2, 0, 810, 0, 0) /* Run                 Trained */
      , (451600195, 31, 0, 3, 0, 820, 0, 0) /* CreatureEnchantment Specialized */
-     , (451600195, 33, 0, 3, 0, 820, 0, 0) /* LifeMagic           Specialized */
+     , (451600195, 33, 0, 3, 0,  50, 0, 0) /* LifeMagic            Specialized */
      , (451600195, 34, 0, 3, 0,22820, 0, 0) /* WarMagic             Specialized */
      , (451600195, 45, 0, 3, 0, 990, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451600195,  0,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451600195,  1,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451600195,  2,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451600195,  3,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451600195,  4,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451600195,  5,  4, 45, 0.75,  300,  393,  522,  360,  132,  489,  174,  489,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451600195,  6,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451600195,  7,  4,  0,    0,  300,  393,  522,  360,  132,  489,  174,  489,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451600195,  8,  4, 45, 0.75,  300,  393,  522,  360,  132,  489,  174,  489,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451600195,  0,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451600195,  1,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451600195,  2,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451600195,  3,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451600195,  4,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451600195,  5,  4, 40, 0.75,  240,  314,  417,  288,  105,  391,  139,  391,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451600195,  6,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451600195,  7,  4,  0,    0,  240,  314,  417,  288,  105,  391,  139,  391,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451600195,  8,  4, 40, 0.75,  240,  314,  417,  288,  105,  391,  139,  391,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451600195,  4455,   2.09) /* Incantation of Shock Wave */
-     , (451600195,  4447,   2.09) /* Incantation of Frost Bolt */
-     , (451600195,  4454,   2.09) /* Incantation of Shock Blast */
-     , (451600195,  4446,   2.08) /* Incantation of Frost Blast */;
+VALUES (451600195,  4455,   2.05) /* Incantation of Shock Wave */
+     , (451600195,  4447,   2.05) /* Incantation of Frost Bolt */
+     , (451600195,  4454,   2.02) /* Incantation of Shock Blast */
+     , (451600195,  4446,   2.02) /* Incantation of Frost Blast */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451600195, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451600199 Death Golem.sql
+++ b/Content/sql/weenies/T9Dungeons/451600199 Death Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600199;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600199, 'T9_deathgolem', 10, '2026-04-30 01:39:07') /* Creature */;
+VALUES (451600199, 'T9_deathgolem', 10, '2026-04-30 08:34:07') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600199,   1,         16) /* ItemType - Creature */
@@ -19,7 +19,7 @@ VALUES (451600199,   1,         16) /* ItemType - Creature */
      , (451600199,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (451600199, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451600199, 146,   35000000) /* XpOverride */
-     , (451600199, 307,         25) /* DamageRating */
+     , (451600199, 307,         30) /* DamageRating */
      , (451600199, 308,         25) /* DamageResistRating */
      , (451600199, 332,       5000) /* LuminanceAward */
      , (451600199, 386,         35) /* Overpower */;
@@ -46,7 +46,7 @@ VALUES (451600199,   1,       5) /* HeartbeatInterval */
      , (451600199,  12,    0.25) /* Shade */
      , (451600199,  13,     0.8) /* ArmorModVsSlash */
      , (451600199,  14,     0.8) /* ArmorModVsPierce */
-     , (451600199,  15,     0.8) /* ArmorModVsBludgeon */
+     , (451600199,  15,     0.7) /* ArmorModVsBludgeon */
      , (451600199,  16,     0.8) /* ArmorModVsCold */
      , (451600199,  17,     0.8) /* ArmorModVsFire */
      , (451600199,  18,     0.8) /* ArmorModVsAcid */
@@ -95,9 +95,9 @@ VALUES (451600199,   1, 700, 0, 0) /* Strength */
      , (451600199,   6,1200, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600199,   1, 22000, 0, 0,32000) /* MaxHealth */
-     , (451600199,   3,     0, 0, 0,20000) /* MaxStamina */
-     , (451600199,   5, 13600, 0, 0,15000) /* MaxMana */;
+VALUES (451600199,   1, 25700, 0, 0,26000) /* MaxHealth */
+     , (451600199,   3, 19400, 0, 0,20000) /* MaxStamina */
+     , (451600199,   5, 13800, 0, 0,15000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (451600199,  6, 0, 3, 0, 214, 0, 0) /* MeleeDefense         Specialized */
@@ -114,22 +114,22 @@ VALUES (451600199,  6, 0, 3, 0, 214, 0, 0) /* MeleeDefense         Specialized *
      , (451600199, 51, 0, 3, 0, 134, 0, 0) /* SneakAttack          Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451600199,  0,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Nether */
-     , (451600199,  1,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Nether */
-     , (451600199,  2,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Nether */
-     , (451600199,  3,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Nether */
-     , (451600199,  4,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Nether */
-     , (451600199,  5,1024,100, 0.75,   90,   39,   52,   78,   30,   30,   72,   90,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Nether */
-     , (451600199,  6,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Nether */
-     , (451600199,  7,1024,  0,    0,   90,   39,   52,   78,   30,   30,   72,   90,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Nether */
-     , (451600199,  8,1024,110, 0.75,   90,   39,   52,   78,   30,   30,   72,   90,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Nether */;
+VALUES (451600199,  0,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Nether */
+     , (451600199,  1,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Nether */
+     , (451600199,  2,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Nether */
+     , (451600199,  3,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Nether */
+     , (451600199,  4,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Nether */
+     , (451600199,  5,1024, 90, 0.75,   63,   27,   36,   54,   21,   21,   50,   63,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Nether */
+     , (451600199,  6,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Nether */
+     , (451600199,  7,1024,  0,    0,   63,   27,   36,   54,   21,   21,   50,   63,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Nether */
+     , (451600199,  8,1024,100, 0.75,   63,   27,   36,   54,   21,   21,   50,   63,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Nether */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451600199,  5402,   2.05) /* Incantation of Corruption */
+VALUES (451600199,  5402,   2.06) /* Incantation of Corruption */
      , (451600199,  5338,   2.05) /* Incantation of Destructive Curse */
-     , (451600199,  4633,   2.04) /* Incantation of Vulnerability Other */
-     , (451600199,  4643,   2.06) /* Incantation of Drain Health Other */
-     , (451600199,  5386,   2.06) /* Incantation of Weakening Curse */;
+     , (451600199,  4633,   2.01) /* Incantation of Vulnerability Other */
+     , (451600199,  4643,   2.05) /* Incantation of Drain Health Other */
+     , (451600199,  5386,   2.02) /* Incantation of Weakening Curse */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (451600199, 2, 21159,  1,93,    0, False) /* Create Covenant Tassets (21159) for Wield */

--- a/Content/sql/weenies/T9Dungeons/451600201 Obsidian Golem.sql
+++ b/Content/sql/weenies/T9Dungeons/451600201 Obsidian Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600201;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600201, 'T9_golemobsidian', 10, '2026-04-06 08:17:37') /* Creature */;
+VALUES (451600201, 'T9_golemobsidian', 10, '2026-04-30 07:29:07') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600201,   1,         16) /* ItemType - Creature */
@@ -19,8 +19,8 @@ VALUES (451600201,   1,         16) /* ItemType - Creature */
      , (451600201,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (451600201, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451600201, 146,   40000000) /* XpOverride */
-     , (451600201, 307,        165) /* DamageRating */
-     , (451600201, 308,         65) /* DamageResistRating */
+     , (451600201, 307,        100) /* DamageRating */
+     , (451600201, 308,         40) /* DamageResistRating */
      , (451600201, 332,       6200) /* LuminanceAward */
      , (451600201, 386,         35) /* Overpower */;
 
@@ -84,21 +84,21 @@ VALUES (451600201,   1, 0x02001516) /* Setup */
      , (451600201,  35,      10021) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451600201,   1,7000, 0, 0) /* Strength */
-     , (451600201,   2,20000, 0, 0) /* Endurance */
+VALUES (451600201,   1,5000, 0, 0) /* Strength */
+     , (451600201,   2,1600, 0, 0) /* Endurance */
      , (451600201,   3, 500, 0, 0) /* Quickness */
      , (451600201,   4,1200, 0, 0) /* Coordination */
      , (451600201,   5,2200, 0, 0) /* Focus */
      , (451600201,   6,1200, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600201,   1, 25000, 0, 0,35000) /* MaxHealth */
-     , (451600201,   3,     0, 0, 0,20000) /* MaxStamina */
-     , (451600201,   5, 17860, 0, 0,18000) /* MaxMana */;
+VALUES (451600201,   1, 24200, 0, 0,25000) /* MaxHealth */
+     , (451600201,   3,   500, 0, 0, 2100) /* MaxStamina */
+     , (451600201,   5, 16800, 0, 0,18000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600201,  6, 0, 3, 0, 234, 0, 0) /* MeleeDefense         Specialized */
-     , (451600201,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense       Specialized */
+VALUES (451600201,  6, 0, 2, 0, 204, 0, 0) /* MeleeDefense             Trained */
+     , (451600201,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense           Trained */
      , (451600201, 14, 0, 2, 0, 200, 0, 0) /* ArcaneLore          Trained */
      , (451600201, 15, 0, 3, 0,   5, 0, 0) /* MagicDefense         Specialized */
      , (451600201, 20, 0, 2, 0, 400, 0, 0) /* Deception                Trained */
@@ -111,21 +111,21 @@ VALUES (451600201,  6, 0, 3, 0, 234, 0, 0) /* MeleeDefense         Specialized *
      , (451600201, 51, 0, 3, 0,5434, 0, 0) /* SneakAttack          Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451600201,  0,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451600201,  1,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451600201,  2,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451600201,  3,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451600201,  4,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451600201,  5,  4, 65, 0.75,  450,  636,  792,  540,  285,  789,  303,  789,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451600201,  6,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451600201,  7,  4,  0,    0,  450,  636,  792,  540,  285,  789,  303,  789,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451600201,  8,  4, 65, 0.75,  450,  636,  792,  540,  285,  789,  303,  789,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451600201,  0,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451600201,  1,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451600201,  2,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451600201,  3,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451600201,  4,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451600201,  5,  4, 60, 0.75,  247,  349,  435,  297,  156,  433,  166,  433,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451600201,  6,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451600201,  7,  4,  0,    0,  247,  349,  435,  297,  156,  433,  166,  433,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451600201,  8,  4, 60, 0.75,  247,  349,  435,  297,  156,  433,  166,  433,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451600201,  4455,   2.09) /* Incantation of Shock Wave */
-     , (451600201,  4451,   2.09) /* Incantation of Lightning Bolt */
-     , (451600201,  4454,   2.09) /* Incantation of Shock Blast */
-     , (451600201,  4450,   2.09) /* Incantation of Lightning Blast */;
+VALUES (451600201,  4455,   2.03) /* Incantation of Shock Wave */
+     , (451600201,  4451,   2.03) /* Incantation of Lightning Bolt */
+     , (451600201,  4454,   2.01) /* Incantation of Shock Blast */
+     , (451600201,  4450,   2.01) /* Incantation of Lightning Blast */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (451600201, 9,361844,  1, 0, 0.04, False) /* Create Metos Shard (361844) for ContainTreasure */

--- a/Content/sql/weenies/T9Dungeons/451600204 Lich.sql
+++ b/Content/sql/weenies/T9Dungeons/451600204 Lich.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600204;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600204, 'T9_zombielich', 10, '2026-04-06 08:17:22') /* Creature */;
+VALUES (451600204, 'T9_zombielich', 10, '2026-04-30 07:01:06') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600204,   1,         16) /* ItemType - Creature */
@@ -69,7 +69,8 @@ VALUES (451600204,   1,       5) /* HeartbeatInterval */
      , (451600204,  80,     2.6) /* AiUseMagicDelay */
      , (451600204, 104,      10) /* ObviousRadarRange */
      , (451600204, 122,       2) /* AiAcquireHealth */
-     , (451600204, 125,       1) /* ResistHealthDrain */;
+     , (451600204, 125,       1) /* ResistHealthDrain */
+     , (451600204, 151,       1) /* IgnoreShield */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (451600204,   1, 'Dread Lich') /* Name */;
@@ -83,7 +84,6 @@ VALUES (451600204,   1, 0x020016A1) /* Setup */
      , (451600204,   7, 0x10000066) /* ClothingBase */
      , (451600204,   8, 0x06001226) /* Icon */
      , (451600204,  22, 0x34000028) /* PhysicsEffectTable */
-     , (451600204,  32,        248) /* WieldedTreasureType */
      , (451600204,  35,      10021) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -95,12 +95,12 @@ VALUES (451600204,   1,1200, 0, 0) /* Strength */
      , (451600204,   6, 650, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600204,   1, 23950, 0, 0,25000) /* MaxHealth */
+VALUES (451600204,   1, 18950, 0, 0,20000) /* MaxHealth */
      , (451600204,   3, 12900, 0, 0,15000) /* MaxStamina */
      , (451600204,   5, 14350, 0, 0,15000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600204,  6, 0, 3, 0,  97, 0, 0) /* MeleeDefense         Specialized */
+VALUES (451600204,  6, 0, 2, 0,  77, 0, 0) /* MeleeDefense             Trained */
      , (451600204,  7, 0, 3, 0, 390, 0, 0) /* MissileDefense       Specialized */
      , (451600204, 14, 0, 3, 0,  50, 0, 0) /* ArcaneLore          Specialized */
      , (451600204, 15, 0, 3, 0, 229, 0, 0) /* MagicDefense         Specialized */
@@ -108,22 +108,19 @@ VALUES (451600204,  6, 0, 3, 0,  97, 0, 0) /* MeleeDefense         Specialized *
      , (451600204, 31, 0, 3, 0, 580, 0, 0) /* CreatureEnchantment Specialized */
      , (451600204, 33, 0, 3, 0, 580, 0, 0) /* LifeMagic           Specialized */
      , (451600204, 34, 0, 3, 0,1125, 0, 0) /* WarMagic             Specialized */
-     , (451600204, 44, 0, 3, 0, 267, 0, 0) /* HeavyWeapons         Specialized */
      , (451600204, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons         Specialized */
-     , (451600204, 46, 0, 3, 0, 517, 0, 0) /* FinesseWeapons       Specialized */
-     , (451600204, 47, 0, 3, 0, 600, 0, 0) /* MissileWeapons       Specialized */
      , (451600204, 51, 0, 3, 0,   0, 0, 0) /* SneakAttack          Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (451600204,  0,  4,  0,    0,  280,  224,   84,  156,   52,  140,  156,  188,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451600204,  1,  4,  0,    0,  320,  256,   96,  176,   56,  160,  176,  216,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451600204,  2,  4,  0,    0,  320,  256,   96,  176,   56,  160,  176,  216,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451600204,  1,  4,  0,    0,  256,  204,   76,  140,   44,  128,  140,  172,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451600204,  2,  4,  0,    0,  256,  204,   76,  140,   44,  128,  140,  172,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
      , (451600204,  3,  4,  0,    0,  280,  224,   84,  156,   52,  140,  156,  188,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451600204,  4,  4,  0,    0,  320,  256,   96,  176,   56,  160,  176,  216,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451600204,  5,  4,  2, 0.75,  320,  256,   96,  176,   56,  160,  176,  216,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451600204,  6,  4,  0,    0,  360,  288,  108,  200,   64,  180,  200,  240,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451600204,  7,  4,  0,    0,  360,  288,  108,  200,   64,  180,  200,  240,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451600204,  8,  4,  3, 0.75,  360,  288,  108,  200,   64,  180,  200,  240,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+     , (451600204,  4,  4,  0,    0,  256,  204,   76,  140,   44,  128,  140,  172,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451600204,  5,1024, 30,  0.5,  256,  204,   76,  140,   44,  128,  140,  172,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Nether */
+     , (451600204,  6,  4,  0,    0,  288,  230,   86,  160,   51,  144,  160,  192,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451600204,  7,  4,  0,    0,  288,  230,   86,  160,   51,  144,  160,  192,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451600204,  8,1024, 30,  0.5,  288,  230,   86,  160,   51,  144,  160,  192,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Nether */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451600204,  4421,  2.029) /* Incantation of Acid Arc */

--- a/Content/sql/weenies/T9Dungeons/451600237 Virindi Master.sql
+++ b/Content/sql/weenies/T9Dungeons/451600237 Virindi Master.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600237;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600237, 'T9_virindimaster', 10, '2026-04-06 08:17:04') /* Creature */;
+VALUES (451600237, 'T9_virindimaster', 10, '2026-04-30 06:24:12') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600237,   1,         16) /* ItemType - Creature */
@@ -19,8 +19,8 @@ VALUES (451600237,   1,         16) /* ItemType - Creature */
      , (451600237, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451600237, 140,          1) /* AiOptions - CanOpenDoors */
      , (451600237, 146,   80000000) /* XpOverride */
-     , (451600237, 307,        150) /* DamageRating */
-     , (451600237, 308,         60) /* DamageResistRating */
+     , (451600237, 307,        90) /* DamageRating */
+     , (451600237, 308,         35) /* DamageResistRating */
      , (451600237, 332,      10000) /* LuminanceAward */
      , (451600237, 386,         15) /* Overpower */;
 
@@ -45,7 +45,7 @@ VALUES (451600237,   1,       5) /* HeartbeatInterval */
      , (451600237,  14,       1) /* ArmorModVsPierce */
      , (451600237,  15,       1) /* ArmorModVsBludgeon */
      , (451600237,  16,    0.72) /* ArmorModVsCold */
-     , (451600237,  17,       1) /* ArmorModVsFire */
+     , (451600237,  17,    0.75) /* ArmorModVsFire */
      , (451600237,  18,       1) /* ArmorModVsAcid */
      , (451600237,  19,    0.72) /* ArmorModVsElectric */
      , (451600237,  31,      18) /* VisualAwarenessRange */
@@ -84,7 +84,7 @@ VALUES (451600237,   1, 0x02000041) /* Setup */
      , (451600237,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451600237,   1,10000, 0, 0) /* Strength */
+VALUES (451600237,   1,1300, 0, 0) /* Strength */
      , (451600237,   2,1505, 0, 0) /* Endurance */
      , (451600237,   3, 920, 0, 0) /* Quickness */
      , (451600237,   4,1200, 0, 0) /* Coordination */
@@ -92,37 +92,36 @@ VALUES (451600237,   1,10000, 0, 0) /* Strength */
      , (451600237,   6, 750, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600237,   1, 35000, 0, 0,70000) /* MaxHealth */
-     , (451600237,   3,  1500, 0, 0, 1500) /* MaxStamina */
-     , (451600237,   5, 30000, 0, 0,30000) /* MaxMana */;
+VALUES (451600237,   1, 18248, 0, 0,19000) /* MaxHealth */
+     , (451600237,   3,   295, 0, 0, 1800) /* MaxStamina */
+     , (451600237,   5, 29250, 0, 0,30000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600237,  6, 0, 3, 0, 70, 0, 0) /* MeleeDefense        Specialized */
-     , (451600237,  7, 0, 3, 0, 200, 0, 0) /* MissileDefense      Specialized */
+VALUES (451600237,  6, 0, 2, 0,  70, 0, 0) /* MeleeDefense             Trained */
+     , (451600237,  7, 0, 2, 0, 326, 0, 0) /* MissileDefense           Trained */
      , (451600237, 14, 0, 2, 0, 230, 0, 0) /* ArcaneLore          Trained */
-     , (451600237, 15, 0, 3, 0, 250, 0, 0) /* MagicDefense        Specialized */
+     , (451600237, 15, 0, 3, 0, 222, 0, 0) /* MagicDefense         Specialized */
      , (451600237, 20, 0, 2, 0, 130, 0, 0) /* Deception           Trained */
      , (451600237, 24, 0, 2, 0, 980, 0, 0) /* Run                 Trained */
      , (451600237, 31, 0, 3, 0,2130, 0, 0) /* CreatureEnchantment Specialized */
      , (451600237, 33, 0, 3, 0,2130, 0, 0) /* LifeMagic           Specialized */
      , (451600237, 34, 0, 3, 0,1830, 0, 0) /* WarMagic            Specialized */
-     , (451600237, 45, 0, 3, 0,4150, 0, 0) /* LightWeapons        Specialized */;
+     , (451600237, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons         Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451600237,  0,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (451600237,  1,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (451600237,  2,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen */
-     , (451600237,  3,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (451600237,  4,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm */
-     , (451600237,  5,  1, 15, 0.75,  300,  300,  300,  300,  220,  300,  300,  220,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (451600237, 17,  1,  0,    0,  300,  300,  300,  300,  220,  300,  300,  220,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail */;
+VALUES (451600237,  0,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Slash */
+     , (451600237,  1,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Slash */
+     , (451600237,  2,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen - Slash */
+     , (451600237,  3,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Slash */
+     , (451600237,  4,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm - Slash */
+     , (451600237,  5,  1, 20, 0.75,  300,  300,  300,  300,  220,  220,  300,  220,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Slash */
+     , (451600237, 17,  1,  0,    0,  300,  300,  300,  300,  220,  220,  300,  220,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail - Slash */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451600237,  6199,   2.06) /* Incantation of Lightning Arc */
      , (451600237,  4439,   2.06) /* Incantation of Flame Bolt */
      , (451600237,  4453,   2.04) /* Incantation of Lightning Volley */
      , (451600237,  4452,   2.04) /* Incantation of Lightning Streak */
-     , (451600237,  3941,   2.04) /* Heavy Lightning Ring */
      , (451600237,  3882,   2.04) /* Incendiary Ring */
      , (451600237,  4441,   2.04) /* Incantation of Flame Volley */
      , (451600237,  4483,   2.06) /* Incantation of Lightning Vulnerability Other */
@@ -132,16 +131,8 @@ VALUES (451600237,  6199,   2.06) /* Incantation of Lightning Arc */
      , (451600237,  4643,   2.02) /* Incantation of Drain Health Other */;
 
 INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (451600237,  94)
-     , (451600237, 414);
-     
-     INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (451600237, 3 /* Death */, 0.0025, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (451600237,         94) /*  */
+     , (451600237,        414) /*  */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451600237, 3 /* Death */, 0.03, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451600619 Revenant.sql
+++ b/Content/sql/weenies/T9Dungeons/451600619 Revenant.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451600619;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451600619, 'T9_zombierevenant', 10, '2026-04-06 08:16:45') /* Creature */;
+VALUES (451600619, 'T9_zombierevenant', 10, '2026-04-30 07:08:57') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451600619,   1,         16) /* ItemType - Creature */
@@ -83,7 +83,6 @@ VALUES (451600619,   1, 0x020016A5) /* Setup */
      , (451600619,   7, 0x10000610) /* ClothingBase */
      , (451600619,   8, 0x06001226) /* Icon */
      , (451600619,  22, 0x34000025) /* PhysicsEffectTable */
-     , (451600619,  32,        250) /* WieldedTreasureType */
      , (451600619,  35,      10021) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -95,15 +94,15 @@ VALUES (451600619,   1, 800, 0, 0) /* Strength */
      , (451600619,   6, 500, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451600619,   1, 25735, 0, 0,31235) /* MaxHealth */
-     , (451600619,   3, 20235, 0, 0,31235) /* MaxStamina */
-     , (451600619,   5, 31080, 0, 0,31235) /* MaxMana */;
+VALUES (451600619,   1, 23500, 0, 0,25000) /* MaxHealth */
+     , (451600619,   3, 28235, 0, 0,31235) /* MaxStamina */
+     , (451600619,   5, 30735, 0, 0,31235) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451600619,  6, 0, 3, 0,  80, 0, 0) /* MeleeDefense         Specialized */
-     , (451600619,  7, 0, 3, 0, 380, 0, 0) /* MissileDefense       Specialized */
+VALUES (451600619,  6, 0, 2, 0,  70, 0, 0) /* MeleeDefense             Trained */
+     , (451600619,  7, 0, 2, 0, 380, 0, 0) /* MissileDefense           Trained */
      , (451600619, 14, 0, 3, 0, 230, 0, 0) /* ArcaneLore          Specialized */
-     , (451600619, 15, 0, 3, 0, 239, 0, 0) /* MagicDefense         Specialized */
+     , (451600619, 15, 0, 2, 0, 224, 0, 0) /* MagicDefense             Trained */
      , (451600619, 20, 0, 3, 0, 400, 0, 0) /* Deception            Specialized */
      , (451600619, 31, 0, 3, 0, 870, 0, 0) /* CreatureEnchantment Specialized */
      , (451600619, 33, 0, 3, 0, 870, 0, 0) /* LifeMagic           Specialized */
@@ -111,29 +110,24 @@ VALUES (451600619,  6, 0, 3, 0,  80, 0, 0) /* MeleeDefense         Specialized *
      , (451600619, 44, 0, 3, 0,8200, 0, 0) /* HeavyWeapons        Specialized */
      , (451600619, 45, 0, 3, 0,8200, 0, 0) /* LightWeapons        Specialized */
      , (451600619, 46, 0, 3, 0,8120, 0, 0) /* FinesseWeapons      Specialized */
-     , (451600619, 47, 0, 3, 0,8150, 0, 0) /* MissileWeapons      Specialized */
-     , (451600619, 48, 0, 3, 0, 200, 0, 0) /* Shield              Specialized */
      , (451600619, 51, 0, 3, 0,3300, 0, 0) /* SneakAttack          Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451600619,  0,  4,  0,    0,  525,  420,  248,  343,   17,  262,  343,  378,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451600619,  1,  4,  0,    0,  525,  420,  248,  343,   17,  262,  343,  378,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451600619,  2,  4,  0,    0,  525,  420,  248,  343,   17,  262,  343,  378,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451600619,  3,  4,  0,    0,  525,  420,  248,  343,   17,  262,  343,  378,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451600619,  4,  4,  0,    0,  525,  420,  248,  343,   17,  262,  343,  378,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451600619,  5,  4,  2, 0.75,  525,  420,  248,  343,   17,  262,  343,  378,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451600619,  6,  4,  0,    0,  560,  448,  262,  364,   17,  280,  364,  402,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451600619,  7,  4,  0,    0,  560,  448,  262,  364,   17,  280,  364,  402,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451600619,  8,  4,  3, 0.75,  560,  448,  262,  364,   17,  280,  364,  402,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451600619,  0,  4,  0,    0,  367,  294,  173,  240,   11,  183,  240,  264,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451600619,  1,  4,  0,    0,  367,  294,  173,  240,   11,  183,  240,  264,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451600619,  2,  4,  0,    0,  367,  294,  173,  240,   11,  183,  240,  264,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451600619,  3,  4,  0,    0,  367,  294,  173,  240,   11,  183,  240,  264,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451600619,  4,  4,  0,    0,  367,  294,  173,  240,   11,  183,  240,  264,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451600619,  5,  4,  2, 0.75,  367,  294,  173,  240,   11,  183,  240,  264,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451600619,  6,  4,  0,    0,  392,  313,  183,  254,   11,  196,  254,  281,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451600619,  7,  4,  0,    0,  392,  313,  183,  254,   11,  196,  254,  281,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451600619,  8,  4,  3, 0.75,  392,  313,  183,  254,   11,  196,  254,  281,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451600619,  4423,  2.029) /* Incantation of Flame Arc */
-     , (451600619,  4424,  2.029) /* Incantation of Force Arc */
-     , (451600619,  4422,  2.029) /* Incantation of Blade Arc */
-     , (451600619,  4643,   2.02) /* Incantation of Drain Health Other */
-     , (451600619,  4435,  2.009) /* Incantation of Blade Blast */
-     , (451600619,  4438,  2.009) /* Incantation of Flame Blast */
-     , (451600619,  4442,  2.009) /* Incantation of Force Blast */;
+VALUES (451600619,  4423,   2.02) /* Incantation of Flame Arc */
+     , (451600619,  4424,   2.02) /* Incantation of Force Arc */
+     , (451600619,  4422,   2.02) /* Incantation of Blade Arc */
+     , (451600619,  4643,   2.01) /* Incantation of Drain Health Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451600619, 3 /* Death */, 0.0025, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451601609 Drudge Stalker.sql
+++ b/Content/sql/weenies/T9Dungeons/451601609 Drudge Stalker.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451601609;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451601609, 'T9_drudgestalker', 10, '2026-04-06 08:16:29') /* Creature */;
+VALUES (451601609, 'T9_drudgestalker', 10, '2026-04-30 06:09:42') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451601609,   1,         16) /* ItemType - Creature */
@@ -21,8 +21,8 @@ VALUES (451601609,   1,         16) /* ItemType - Creature */
      , (451601609, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451601609, 140,          1) /* AiOptions - CanOpenDoors */
      , (451601609, 146,   25000000) /* XpOverride */
-     , (451601609, 307,         60) /* DamageRating */
-     , (451601609, 308,         35) /* DamageResistRating */
+     , (451601609, 307,         50) /* DamageRating */
+     , (451601609, 308,         25) /* DamageResistRating */
      , (451601609, 332,       2000) /* LuminanceAward */
      , (451601609, 386,         30) /* Overpower */;
 
@@ -47,7 +47,7 @@ VALUES (451601609,   1,       5) /* HeartbeatInterval */
      , (451601609,  14,    0.69) /* ArmorModVsPierce */
      , (451601609,  15,     0.9) /* ArmorModVsBludgeon */
      , (451601609,  16,    0.86) /* ArmorModVsCold */
-     , (451601609,  17,     0.9) /* ArmorModVsFire */
+     , (451601609,  17,    0.75) /* ArmorModVsFire */
      , (451601609,  18,    0.86) /* ArmorModVsAcid */
      , (451601609,  19,    0.36) /* ArmorModVsElectric */
      , (451601609,  31,      24) /* VisualAwarenessRange */
@@ -87,7 +87,7 @@ VALUES (451601609,   1, 0x020007DD) /* Setup */
      , (451601609,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451601609,   1,4000, 0, 0) /* Strength */
+VALUES (451601609,   1,3500, 0, 0) /* Strength */
      , (451601609,   2, 290, 0, 0) /* Endurance */
      , (451601609,   3, 325, 0, 0) /* Quickness */
      , (451601609,   4,1500, 0, 0) /* Coordination */
@@ -95,19 +95,19 @@ VALUES (451601609,   1,4000, 0, 0) /* Strength */
      , (451601609,   6, 310, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451601609,   1, 22000, 0, 0,23000) /* MaxHealth */
-     , (451601609,   3,  4000, 0, 0, 5900) /* MaxStamina */
-     , (451601609,   5,   250, 0, 0, 3600) /* MaxMana */;
+VALUES (451601609,   1, 18855, 0, 0,19000) /* MaxHealth */
+     , (451601609,   3,  5610, 0, 0, 5900) /* MaxStamina */
+     , (451601609,   5,  3290, 0, 0, 3600) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451601609,  6, 0, 3, 0, 172, 0, 0) /* MeleeDefense         Specialized */
+VALUES (451601609,  6, 0, 2, 0, 152, 0, 0) /* MeleeDefense             Trained */
      , (451601609,  7, 0, 3, 0, 390, 0, 0) /* MissileDefense      Specialized */
      , (451601609, 14, 0, 2, 0, 200, 0, 0) /* ArcaneLore          Trained */
-     , (451601609, 15, 0, 3, 0, 350, 0, 0) /* MagicDefense        Specialized */
+     , (451601609, 15, 0, 3, 0, 362, 0, 0) /* MagicDefense         Specialized */
      , (451601609, 20, 0, 2, 0, 120, 0, 0) /* Deception           Trained */
      , (451601609, 24, 0, 2, 0,  55, 0, 0) /* Run                 Trained */
-     , (451601609, 31, 0, 3, 0, 395, 0, 0) /* CreatureEnchantment Specialized */
-     , (451601609, 33, 0, 3, 0, 500, 0, 0) /* LifeMagic           Specialized */
+     , (451601609, 31, 0, 3, 0, 445, 0, 0) /* CreatureEnchantment  Specialized */
+     , (451601609, 33, 0, 3, 0, 445, 0, 0) /* LifeMagic            Specialized */
      , (451601609, 34, 0, 3, 0, 500, 0, 0) /* WarMagic            Specialized */
      , (451601609, 45, 0, 3, 0,4900, 0, 0) /* LightWeapons        Specialized */
      , (451601609, 44, 0, 2, 0,4900, 0, 0) /* HeavyWeapons        Trained */
@@ -115,24 +115,23 @@ VALUES (451601609,  6, 0, 3, 0, 172, 0, 0) /* MeleeDefense         Specialized *
      , (451601609, 47, 0, 3, 0, 900, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451601609,  0,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (451601609,  1,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (451601609,  2,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (451601609,  3,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (451601609,  4,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (451601609,  5,  4,225, 0.75,  400,  400,  400,  400,  320,  400,  400,  320,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (451601609,  6,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (451601609,  7,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (451601609,  8,  4,225, 0.75,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (451601609,  0,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451601609,  1,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451601609,  2,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451601609,  3,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451601609,  4,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451601609,  5,  4,175, 0.75,  320,  320,  320,  320,  256,  256,  320,  256,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451601609,  6,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451601609,  7,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451601609,  8,  4,175, 0.75,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451601609,  6199,  2.085) /* Incantation of Lightning Arc */
-     , (451601609,  4312,   2.04) /* Incantation of Imperil Other */
+VALUES (451601609,  4312,   2.04) /* Incantation of Imperil Other */
      , (451601609,  4322,   2.03) /* Incantation of Slowness Other */;
 
 INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (451601609,  94)
-     , (451601609, 414);
+VALUES (451601609,          94) /*  */
+     , (451601609,          414) /*  */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451601609, 3 /* Death */, 0.0025, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451601610 Drudge Ravener.sql
+++ b/Content/sql/weenies/T9Dungeons/451601610 Drudge Ravener.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451601610;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451601610, 'T9_drudgeravener', 10, '2026-04-06 08:16:17') /* Creature */;
+VALUES (451601610, 'T9_drudgeravener', 10, '2026-04-30 06:24:10') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451601610,   1,         16) /* ItemType - Creature */
@@ -21,8 +21,8 @@ VALUES (451601610,   1,         16) /* ItemType - Creature */
      , (451601610, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451601610, 140,          1) /* AiOptions - CanOpenDoors */
      , (451601610, 146,   30000000) /* XpOverride */
-     , (451601610, 307,         80) /* DamageRating */
-     , (451601610, 308,         55) /* DamageResistRating */
+     , (451601610, 307,         70) /* DamageRating */
+     , (451601610, 308,         35) /* DamageResistRating */
      , (451601610, 332,       4000) /* LuminanceAward */
      , (451601610, 386,         30) /* Overpower */;
 
@@ -47,7 +47,7 @@ VALUES (451601610,   1,       5) /* HeartbeatInterval */
      , (451601610,  14,     0.7) /* ArmorModVsPierce */
      , (451601610,  15,     0.9) /* ArmorModVsBludgeon */
      , (451601610,  16,    0.86) /* ArmorModVsCold */
-     , (451601610,  17,     0.9) /* ArmorModVsFire */
+     , (451601610,  17,    0.75) /* ArmorModVsFire */
      , (451601610,  18,    0.86) /* ArmorModVsAcid */
      , (451601610,  19,    0.38) /* ArmorModVsElectric */
      , (451601610,  31,      24) /* VisualAwarenessRange */
@@ -95,19 +95,19 @@ VALUES (451601610,   1,4000, 0, 0) /* Strength */
      , (451601610,   6, 310, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451601610,   1, 26000, 0, 0,29000) /* MaxHealth */
-     , (451601610,   3,  4000, 0, 0, 5900) /* MaxStamina */
-     , (451601610,   5,   250, 0, 0, 3600) /* MaxMana */;
+VALUES (451601610,   1, 21855, 0, 0,22000) /* MaxHealth */
+     , (451601610,   3,  5610, 0, 0, 5900) /* MaxStamina */
+     , (451601610,   5,  3290, 0, 0, 3600) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451601610,  6, 0, 3, 0, 150, 0, 0) /* MeleeDefense         Specialized */
-     , (451601610,  7, 0, 3, 0, 390, 0, 0) /* MissileDefense      Specialized */
+VALUES (451601610,  6, 0, 2, 0, 150, 0, 0) /* MeleeDefense             Trained */
+     , (451601610,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense           Trained */
      , (451601610, 14, 0, 2, 0, 200, 0, 0) /* ArcaneLore          Trained */
-     , (451601610, 15, 0, 3, 0, 350, 0, 0) /* MagicDefense        Specialized */
+     , (451601610, 15, 0, 2, 0, 350, 0, 0) /* MagicDefense             Trained */
      , (451601610, 20, 0, 2, 0, 120, 0, 0) /* Deception           Trained */
      , (451601610, 24, 0, 2, 0,  55, 0, 0) /* Run                 Trained */
      , (451601610, 31, 0, 3, 0, 395, 0, 0) /* CreatureEnchantment Specialized */
-     , (451601610, 33, 0, 3, 0, 500, 0, 0) /* LifeMagic           Specialized */
+     , (451601610, 33, 0, 3, 0, 395, 0, 0) /* LifeMagic            Specialized */
      , (451601610, 34, 0, 3, 0, 500, 0, 0) /* WarMagic            Specialized */
      , (451601610, 45, 0, 3, 0,4900, 0, 0) /* LightWeapons        Specialized */
      , (451601610, 44, 0, 2, 0,4900, 0, 0) /* HeavyWeapons        Trained */
@@ -115,25 +115,24 @@ VALUES (451601610,  6, 0, 3, 0, 150, 0, 0) /* MeleeDefense         Specialized *
      , (451601610, 47, 0, 3, 0, 900, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451601610,  0,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (451601610,  1,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (451601610,  2,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (451601610,  3,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (451601610,  4,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (451601610,  5,  4,225, 0.75,  400,  400,  400,  400,  320,  400,  400,  320,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (451601610,  6,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (451601610,  7,  4,  0,    0,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (451601610,  8,  4,225, 0.75,  400,  400,  400,  400,  320,  400,  400,  320,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (451601610,  0,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451601610,  1,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451601610,  2,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451601610,  3,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451601610,  4,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451601610,  5,  4,175, 0.75,  320,  320,  320,  320,  256,  256,  320,  256,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451601610,  6,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451601610,  7,  4,  0,    0,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451601610,  8,  4,175, 0.75,  320,  320,  320,  320,  256,  256,  320,  256,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (451601610,  6199,  2.085) /* Incantation of Lightning Arc */
-     , (451601610,  4312,   2.04) /* Incantation of Imperil Other */
+VALUES (451601610,  4312,   2.04) /* Incantation of Imperil Other */
      , (451601610,  4322,   2.03) /* Incantation of Slowness Other */;
 
 INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (451601610,  94)
-     , (451601610, 414);
-     
+VALUES (451601610,          94) /*  */
+     , (451601610,          414) /*  */;
+
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451601610, 3 /* Death */, 0.0025, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 

--- a/Content/sql/weenies/T9Dungeons/451601628 Tusker Slave.sql
+++ b/Content/sql/weenies/T9Dungeons/451601628 Tusker Slave.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451601628;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451601628, 'T9_tuskerslave', 10, '2026-04-30 12:07:17') /* Creature */;
+VALUES (451601628, 'T9_tuskerslave', 10, '2026-04-30 05:29:04') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451601628,   1,         16) /* ItemType - Creature */
@@ -80,7 +80,7 @@ VALUES (451601628,   1, 0x02000964) /* Setup */
      , (451601628,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451601628,   1, 980, 0, 0) /* Strength */
+VALUES (451601628,   1, 800, 0, 0) /* Strength */
      , (451601628,   2, 600, 0, 0) /* Endurance */
      , (451601628,   3, 380, 0, 0) /* Quickness */
      , (451601628,   4,1500, 0, 0) /* Coordination */
@@ -88,33 +88,33 @@ VALUES (451601628,   1, 980, 0, 0) /* Strength */
      , (451601628,   6, 180, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451601628,   1, 29700, 0, 0,30000) /* MaxHealth */
+VALUES (451601628,   1, 26700, 0, 0,27000) /* MaxHealth */
      , (451601628,   3,  5400, 0, 0, 6000) /* MaxStamina */
      , (451601628,   5,     0, 0, 0,  180) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451601628,  6, 0, 3, 0, 174, 0, 0) /* MeleeDefense         Specialized */
-     , (451601628,  7, 0, 3, 0, 450, 0, 0) /* MissileDefense      Specialized */
-     , (451601628, 15, 0, 3, 0, 380, 0, 0) /* MagicDefense        Specialized */
+VALUES (451601628,  6, 0, 2, 0, 149, 0, 0) /* MeleeDefense             Trained */
+     , (451601628,  7, 0, 3, 0, 424, 0, 0) /* MissileDefense       Specialized */
+     , (451601628, 15, 0, 2, 0, 388, 0, 0) /* MagicDefense             Trained */
      , (451601628, 20, 0, 2, 0,  50, 0, 0) /* Deception           Trained */
      , (451601628, 22, 0, 2, 0, 115, 0, 0) /* Jump                Trained */
      , (451601628, 24, 0, 2, 0,  60, 0, 0) /* Run                 Trained */
-     , (451601628, 45, 0, 3, 0, 250, 0, 0) /* LightWeapons        Specialized */;
+     , (451601628, 45, 0, 3, 0, 300, 0, 0) /* LightWeapons         Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451601628,  0,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (451601628,  1,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (451601628,  2,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (451601628,  3,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (451601628,  4,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (451601628,  5,1024,100, 0.75,  450,  225,  360,  297,  450,  315,  450,  450,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (451601628,  6,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (451601628,  7,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (451601628,  8,1024,110, 0.75,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (451601628,  0,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Nether */
+     , (451601628,  1,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Nether */
+     , (451601628,  2,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Nether */
+     , (451601628,  3,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Nether */
+     , (451601628,  4,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Nether */
+     , (451601628,  5,1024, 70, 0.25,  360,  180,  288,  237,  360,  252,  360,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Nether */
+     , (451601628,  6,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Nether */
+     , (451601628,  7,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Nether */
+     , (451601628,  8,1024, 80, 0.25,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Nether */;
 
 INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (451601628,  94)
-     , (451601628, 414);
+VALUES (451601628,         94) /*  */
+     , (451601628,        414) /*  */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451601628, 5 /* HeartBeat */, 0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451601629 Tusker Guard.sql
+++ b/Content/sql/weenies/T9Dungeons/451601629 Tusker Guard.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451601629;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451601629, 'T9_tuskerguard', 10, '2026-04-30 12:06:26') /* Creature */;
+VALUES (451601629, 'T9_tuskerguard', 10, '2026-04-30 05:29:06') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451601629,   1,         16) /* ItemType - Creature */
@@ -78,7 +78,7 @@ VALUES (451601629,   1, 0x02000964) /* Setup */
      , (451601629,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451601629,   1,1110, 0, 0) /* Strength */
+VALUES (451601629,   1, 900, 0, 0) /* Strength */
      , (451601629,   2, 300, 0, 0) /* Endurance */
      , (451601629,   3, 180, 0, 0) /* Quickness */
      , (451601629,   4,1500, 0, 0) /* Coordination */
@@ -86,33 +86,33 @@ VALUES (451601629,   1,1110, 0, 0) /* Strength */
      , (451601629,   6,  60, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451601629,   1, 35000, 0, 0,35000) /* MaxHealth */
-     , (451601629,   3,  5400, 0, 0, 6000) /* MaxStamina */
-     , (451601629,   5,     0, 0, 0,  180) /* MaxMana */;
+VALUES (451601629,   1, 30850, 0, 0,31000) /* MaxHealth */
+     , (451601629,   3,  5700, 0, 0, 6000) /* MaxStamina */
+     , (451601629,   5,   120, 0, 0,  180) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451601629,  6, 0, 3, 0, 240, 0, 0) /* MeleeDefense         Specialized */
-     , (451601629,  7, 0, 3, 0, 450, 0, 0) /* MissileDefense      Specialized */
-     , (451601629, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
+VALUES (451601629,  6, 0, 2, 0, 215, 0, 0) /* MeleeDefense             Trained */
+     , (451601629,  7, 0, 3, 0, 464, 0, 0) /* MissileDefense       Specialized */
+     , (451601629, 15, 0, 2, 0, 412, 0, 0) /* MagicDefense             Trained */
      , (451601629, 20, 0, 2, 0,  50, 0, 0) /* Deception           Trained */
      , (451601629, 22, 0, 2, 0, 115, 0, 0) /* Jump                Trained */
      , (451601629, 24, 0, 2, 0,  60, 0, 0) /* Run                 Trained */
-     , (451601629, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
+     , (451601629, 45, 0, 3, 0, 274, 0, 0) /* LightWeapons         Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451601629,  0,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (451601629,  1,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (451601629,  2,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (451601629,  3,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (451601629,  4,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (451601629,  5,1024,100, 0.75,  450,  225,  360,  297,  450,  315,  450,  450,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (451601629,  6,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (451601629,  7,1024,  0,    0,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (451601629,  8,1024,110, 0.75,  450,  225,  360,  297,  450,  315,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (451601629,  0,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Nether */
+     , (451601629,  1,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Nether */
+     , (451601629,  2,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Nether */
+     , (451601629,  3,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Nether */
+     , (451601629,  4,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Nether */
+     , (451601629,  5,1024, 70, 0.75,  360,  180,  288,  237,  360,  252,  360,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Nether */
+     , (451601629,  6,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Nether */
+     , (451601629,  7,1024,  0,    0,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Nether */
+     , (451601629,  8,1024, 80, 0.75,  360,  180,  288,  237,  360,  252,  360,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Nether */;
 
 INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (451601629,  94)
-     , (451601629, 414);
+VALUES (451601629,          94) /*  */
+     , (451601629,          414) /*  */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451601629, 3 /* Death */, 0.0025, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Content/sql/weenies/T9Dungeons/451601630 Lich Lord.sql
+++ b/Content/sql/weenies/T9Dungeons/451601630 Lich Lord.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451601630;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451601630, 'T9_zombielichlord', 10, '2026-04-06 08:15:34') /* Creature */;
+VALUES (451601630, 'T9_zombielichlord', 10, '2026-04-30 07:01:04') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451601630,   1,         16) /* ItemType - Creature */
@@ -83,7 +83,6 @@ VALUES (451601630,   1, 0x020016A1) /* Setup */
      , (451601630,   7, 0x10000066) /* ClothingBase */
      , (451601630,   8, 0x06001226) /* Icon */
      , (451601630,  22, 0x34000028) /* PhysicsEffectTable */
-     , (451601630,  32,        249) /* WieldedTreasureType */
      , (451601630,  35,      10021) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -95,36 +94,32 @@ VALUES (451601630,   1,1200, 0, 0) /* Strength */
      , (451601630,   6,1600, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451601630,   1, 34800, 0, 0,36000) /* MaxHealth */
+VALUES (451601630,   1, 23800, 0, 0,25000) /* MaxHealth */
      , (451601630,   3, 27600, 0, 0,30000) /* MaxStamina */
      , (451601630,   5, 28400, 0, 0,30000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451601630,  6, 0, 3, 0,  30, 0, 0) /* MeleeDefense         Specialized */
-     , (451601630,  7, 0, 3, 0, 350, 0, 0) /* MissileDefense       Specialized */
+VALUES (451601630,  6, 0, 2, 0,  10, 0, 0) /* MeleeDefense             Trained */
+     , (451601630,  7, 0, 2, 0, 350, 0, 0) /* MissileDefense           Trained */
      , (451601630, 14, 0, 2, 0, 200, 0, 0) /* ArcaneLore          Trained */
      , (451601630, 15, 0, 3, 0,  43, 0, 0) /* MagicDefense         Specialized */
      , (451601630, 20, 0, 3, 0, 400, 0, 0) /* Deception            Specialized */
      , (451601630, 31, 0, 3, 0, 400, 0, 0) /* CreatureEnchantment  Specialized */
      , (451601630, 33, 0, 3, 0, 400, 0, 0) /* LifeMagic            Specialized */
      , (451601630, 34, 0, 3, 0,1000, 0, 0) /* WarMagic             Specialized */
-     , (451601630, 44, 0, 3, 0,6125, 0, 0) /* HeavyWeapons        Specialized */
      , (451601630, 45, 0, 3, 0,6125, 0, 0) /* LightWeapons        Specialized */
-     , (451601630, 46, 0, 3, 0,6125, 0, 0) /* FinesseWeapons      Specialized */
-     , (451601630, 47, 0, 3, 0,3980, 0, 0) /* MissileWeapons       Specialized */
-     , (451601630, 48, 0, 3, 0, 125, 0, 0) /* Shield              Specialized */
      , (451601630, 51, 0, 3, 0,   0, 0, 0) /* SneakAttack          Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451601630,  0,  4,  0,    0,  363,  290,  151,  224,  138,  181,  224,  254,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451601630,  1,  4,  0,    0,  396,  316,  165,  244,  151,  198,  244,  277,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451601630,  2,  4,  0,    0,  396,  316,  165,  244,  151,  198,  244,  277,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451601630,  3,  4,  0,    0,  363,  290,  151,  224,  138,  181,  224,  254,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451601630,  4,  4,  0,    0,  396,  316,  165,  244,  151,  198,  244,  277,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451601630,  5,  4,  2, 0.75,  429,  343,  181,  267,  161,  214,  267,  300,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451601630,  6,  4,  0,    0,  429,  343,  181,  267,  161,  214,  267,  300,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451601630,  7,  4,  0,    0,  429,  343,  181,  267,  161,  214,  267,  300,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451601630,  8,  4,  3, 0.75,  429,  343,  181,  267,  161,  214,  267,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451601630,  0,  4,  0,    0,  254,  203,  105,  156,   96,  126,  156,  177,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451601630,  1,  4,  0,    0,  277,  221,  115,  170,  105,  138,  170,  193,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451601630,  2,  4,  0,    0,  277,  221,  115,  170,  105,  138,  170,  193,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451601630,  3,  4,  0,    0,  254,  203,  105,  156,   96,  126,  156,  177,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451601630,  4,  4,  0,    0,  277,  221,  115,  170,  105,  138,  170,  193,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451601630,  5,1024, 20,  0.5,  300,  240,  126,  186,  112,  149,  186,  210,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Nether */
+     , (451601630,  6,  4,  0,    0,  300,  240,  126,  186,  112,  149,  186,  210,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451601630,  7,  4,  0,    0,  300,  240,  126,  186,  112,  149,  186,  210,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451601630,  8,1024, 20,  0.5,  300,  240,  126,  186,  112,  149,  186,  210,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Nether */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451601630,  4433,   2.04) /* Incantation of Acid Stream */
@@ -134,9 +129,9 @@ VALUES (451601630,  4433,   2.04) /* Incantation of Acid Stream */
      , (451601630,  4439,   2.04) /* Incantation of Flame Bolt */
      , (451601630,  4443,   2.04) /* Incantation of Force Bolt */
      , (451601630,  4457,   2.04) /* Incantation of Whirling Blade */
-     , (451601630,  4431,   2.04) /* Incantation of Acid Blast */
-     , (451601630,  4446,   2.04) /* Incantation of Frost Blast */
-     , (451601630,  4450,   2.04) /* Incantation of Lightning Blast */
+     , (451601630,  4431,   2.01) /* Incantation of Acid Blast */
+     , (451601630,  4446,   2.01) /* Incantation of Frost Blast */
+     , (451601630,  4450,   2.01) /* Incantation of Lightning Blast */
      , (451601630,  4438,   2.04) /* Incantation of Flame Blast */
      , (451601630,  4643,   2.04) /* Incantation of Drain Health Other */;
 

--- a/Content/sql/weenies/T9Dungeons/451601700 Harbinger.sql
+++ b/Content/sql/weenies/T9Dungeons/451601700 Harbinger.sql
@@ -1,0 +1,235 @@
+DELETE FROM `weenie` WHERE `class_Id` = 451601700;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (451601700, 'T9_BSDHarbinger', 10, '2026-04-30 04:39:32') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (451601700,   1,         16) /* ItemType - Creature */
+     , (451601700,   2,         62) /* CreatureType - Elemental */
+     , (451601700,   6,         -1) /* ItemsCapacity */
+     , (451601700,   7,         -1) /* ContainersCapacity */
+     , (451601700,  16,          1) /* ItemUseable - No */
+     , (451601700,  25,        999) /* Level */
+     , (451601700,  27,          0) /* ArmorType - None */
+     , (451601700,  40,          1) /* CombatMode - NonCombat */
+     , (451601700,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (451601700,  69,         30) /* CombatTactic - Focused, LastDamager, TopDamager, Weakest */
+     , (451601700,  72,         62) /* FriendType - Elemental */
+     , (451601700,  81,          1) /* MaxGeneratedObjects */
+     , (451601700,  82,          0) /* InitGeneratedObjects */
+     , (451601700,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (451601700, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (451601700, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (451601700, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (451601700, 146,  100000000) /* XpOverride */
+     , (451601700, 307,         80) /* DamageRating */
+     , (451601700, 308,         40) /* DamageResistRating */
+     , (451601700, 332,     100000) /* LuminanceAward */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (451601700,   1, True ) /* Stuck */
+     , (451601700,   6, True ) /* AiUsesMana */
+     , (451601700,  11, False) /* IgnoreCollisions */
+     , (451601700,  12, True ) /* ReportCollisions */
+     , (451601700,  13, False) /* Ethereal */
+     , (451601700,  29, True ) /* NoCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (451601700,   1,       5) /* HeartbeatInterval */
+     , (451601700,   2,       0) /* HeartbeatTimestamp */
+     , (451601700,   3,       0) /* HealthRate */
+     , (451601700,   4,     200) /* StaminaRate */
+     , (451601700,   5,     200) /* ManaRate */
+     , (451601700,  13,       1) /* ArmorModVsSlash */
+     , (451601700,  14,       1) /* ArmorModVsPierce */
+     , (451601700,  15,       1) /* ArmorModVsBludgeon */
+     , (451601700,  16,     100) /* ArmorModVsCold */
+     , (451601700,  17,     100) /* ArmorModVsFire */
+     , (451601700,  18,     100) /* ArmorModVsAcid */
+     , (451601700,  19,     100) /* ArmorModVsElectric */
+     , (451601700,  31,      20) /* VisualAwarenessRange */
+     , (451601700,  34,       1) /* PowerupTime */
+     , (451601700,  36,       1) /* ChargeSpeed */
+     , (451601700,  39,       2) /* DefaultScale */
+     , (451601700,  41,       0) /* RegenerationInterval */
+     , (451601700,  43,      10) /* GeneratorRadius */
+     , (451601700,  64,       1) /* ResistSlash */
+     , (451601700,  65,       1) /* ResistPierce */
+     , (451601700,  66,       1) /* ResistBludgeon */
+     , (451601700,  67,       0) /* ResistFire */
+     , (451601700,  68,       0) /* ResistCold */
+     , (451601700,  69,       0) /* ResistAcid */
+     , (451601700,  70,       0) /* ResistElectric */
+     , (451601700,  71,       1) /* ResistHealthBoost */
+     , (451601700,  72,       1) /* ResistStaminaDrain */
+     , (451601700,  73,       1) /* ResistStaminaBoost */
+     , (451601700,  74,       1) /* ResistManaDrain */
+     , (451601700,  75,       1) /* ResistManaBoost */
+     , (451601700,  80,       0) /* AiUseMagicDelay */
+     , (451601700, 104,      10) /* ObviousRadarRange */
+     , (451601700, 117,     0.7) /* FocusedProbability */
+     , (451601700, 125,       1) /* ResistHealthDrain */
+     , (451601700, 151,       1) /* IgnoreShield */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (451601700,   1, 'Harbinger') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (451601700,   1, 0x02001731) /* Setup */
+     , (451601700,   2, 0x09000111) /* MotionTable */
+     , (451601700,   3, 0x20000093) /* SoundTable */
+     , (451601700,   4, 0x30000000) /* CombatTable */
+     , (451601700,   7, 0x100003ED) /* ClothingBase */
+     , (451601700,   8, 0x060027CB) /* Icon */
+     , (451601700,  22, 0x34000063) /* PhysicsEffectTable */
+     , (451601700,  31,      87777) /* LinkedPortalOne - Surface */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (451601700, 0, 0x0, 0, 0, 0, 0, 0, 0, 0) /* Undef */
+/* @teleloc 0x0 [0.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 0.000000 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (451601700,   1,1000, 0, 0) /* Strength */
+     , (451601700,   2, 800, 0, 0) /* Endurance */
+     , (451601700,   3, 800, 0, 0) /* Quickness */
+     , (451601700,   4, 800, 0, 0) /* Coordination */
+     , (451601700,   5, 800, 0, 0) /* Focus */
+     , (451601700,   6, 800, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (451601700,   1,174600, 0, 0,175000) /* MaxHealth */
+     , (451601700,   3, 89200, 0, 0,90000) /* MaxStamina */
+     , (451601700,   5,199200, 0, 0,200000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (451601700,  6, 0, 3, 0, 242, 0, 0) /* MeleeDefense         Specialized */
+     , (451601700,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense       Specialized */
+     , (451601700, 15, 0, 2, 0, 272, 0, 0) /* MagicDefense             Trained */
+     , (451601700, 16, 0, 3, 0, 350, 0, 0) /* ManaConversion      Specialized */
+     , (451601700, 22, 0, 3, 0, 100, 0, 0) /* Jump                Specialized */
+     , (451601700, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
+     , (451601700, 31, 0, 3, 0, 250, 0, 0) /* CreatureEnchantment Specialized */
+     , (451601700, 33, 0, 3, 0, 250, 0, 0) /* LifeMagic           Specialized */
+     , (451601700, 34, 0, 3, 0,1100, 0, 0) /* WarMagic            Specialized */
+     , (451601700, 45, 0, 3, 0, 700, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (451601700,  0,  4,  0,    0,  237,  237,  237,  237,23760,23760,23760,23760,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451601700,  1,  4,  0,    0,  237,  237,  237,  237,23760,23760,23760,23760,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451601700,  2,  4,  0,    0,  237,  237,  237,  237,23760,23760,23760,23760,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451601700,  3,  4,  0,    0,  237,  237,  237,  237,19008,19008,19008,19008,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451601700,  4,  4,  0,    0,  237,  237,  237,  237,23760,23760,23760,23760,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451601700,  5,  4,500, 0.75,  237,  237,  237,  237,23760,23760,23760,23760,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451601700,  6,  4,  0,    0,  237,  237,  237,  237,23760,23760,23760,23760,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451601700,  7,  4,  0,    0,  237,  237,  237,  237,23760,23760,23760,23760,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451601700,  8,  4,500, 0.75,  237,  237,  237,  237,23760,23760,23760,23760,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (451601700,  2788,   2.01) /* Essence Blight */
+     , (451601700,  2996,   2.01) /* Scourge */
+     , (451601700,  3928,   2.01) /* Disarmament */
+     , (451601700,  2029,   2.01) /* Stamina Blight */
+     , (451601700,  3883,   2.02) /* Pyroclastic Explosion */
+     , (451601700,  3041,   2.02) /* Essence Dissolution */
+     , (451601700,  3460,   2.02) /* Dissolving Vortex */
+     , (451601700,  3462,   2.02) /* Canker Flesh */
+     , (451601700,  3463,   2.02) /* Char Flesh */
+     , (451601700,  3464,   2.02) /* Numb Flesh */
+     , (451601700,  3916,   2.02) /* Flayed Flesh */
+     , (451601700,  3927,   2.02) /* Charge Flesh */
+     , (451601700,  3904,   2.01) /* Essence's Fury */
+     , (451601700,  3905,   2.01) /* Essence's Fury */
+     , (451601700,  3906,   2.01) /* Essence's Fury */
+     , (451601700,  3907,   2.01) /* Essence's Fury */
+     , (451601700,  3951,   2.02) /* Lightning Wave */
+     , (451601700,  3946,   2.02) /* Acid Wave */
+     , (451601700,  3950,   2.02) /* Frost Wave */
+     , (451601700,  3948,   2.02) /* Flame Wave */
+     , (451601700,  3880,   2.02) /* Galvanic Strike */
+     , (451601700,  3877,   2.02) /* Corrosive Strike */
+     , (451601700,  3879,   2.02) /* Glacial Strike */
+     , (451601700,  3878,   2.02) /* Incendiary Strike */
+     , (451601700,  3885,   2.02) /* Galvanic Ring */
+     , (451601700,  3881,   2.02) /* Corrosive Ring */
+     , (451601700,  3884,   2.02) /* Glacial Ring */
+     , (451601700,  3882,   2.02) /* Incendiary Ring */
+     , (451601700,  3910,   2.01) /* Brain Freeze */
+     , (451601700,  3870,  2.005) /* Syphon Creature Essence */
+     , (451601700,  3871,  2.005) /* Syphon Item Essence */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'The Harbinger''s death cry shakes the walls of the chamber, threatening to cave it in.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 17 /* LocalBroadcast */, 1, 1, NULL, '%tn has temporarily driven the Harbinger from this plane.  As the eldritch being dissolves into prismatic energy, you see a vision of a world enveloped by an alien light.  Its landscape shimmers with impossible colors.  Everything living looks wrong, growing in fractalized dimensions and malformed by cancerous growths like a hundred nascent eyes.  You realize this world is Auberean, your home.  Suddenly, the omen fades, and you struggle to keep your mind from breaking.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 9 /* Generation */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'The air around you grows heavy with electricity, and you feel a sharp pressure building at the front of your skull.  It grows until it becomes unbearable, like an ice pick driving deeper into your brain.  You are vaguely aware of fingers digging into your eye sockets as if attempting to tear out the foreign object.  Suddenly, the pain dissipates and relief courses through your being.  Your hands fall away from your face.  All that''s left is a dim awareness of an alien presence, so alien you''re not sure it''s alive.  You feel drawn to it.  It wants to speak to you.  You''re not sure you want to listen.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 14 /* Taunt */, 0.01, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'The Harbinger turns its alien gaze towards you. In its eyes, you see an endless expanse of elemental energy, threatening to overwhelm you.  You summon all of your will and manage to avert your eyes before it draws you in.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 14 /* Taunt */, 0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'The Harbinger unleashes a blast of prismatic energy at %s. You sense something like amusement ripple across its face, just as quickly replaced by an unfeeling stare.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 15 /* WoundedTaunt */, 1, NULL, NULL, NULL, NULL, NULL, 0.24, 0.27);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 15 /* WoundedTaunt */, 1, NULL, NULL, NULL, NULL, NULL, 0.74, 0.77);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 15 /* WoundedTaunt */, 1, NULL, NULL, NULL, NULL, NULL, 0.97, 1);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601700, 16 /* KillTaunt */, 0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Inhuman eyes stare at you from the blackness. An impossibly cold hand grips your heart and squeezes. Your being fills with pain, there is nothing else. Suddenly it stops and you are falling toward your lifestone.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */
+     , (451601700, 9,361841,  1, 0,    1, False) /* Create Prismatic Harbinger Blood (361841) for ContainTreasure */;
+

--- a/Content/sql/weenies/T9Dungeons/451601702 Commander Dickus.sql
+++ b/Content/sql/weenies/T9Dungeons/451601702 Commander Dickus.sql
@@ -1,0 +1,240 @@
+DELETE FROM `weenie` WHERE `class_Id` = 451601702;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (451601702, 'T9_lugiancitcommander', 10, '2026-04-30 08:25:59') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (451601702,   1,         16) /* ItemType - Creature */
+     , (451601702,   2,         70) /* CreatureType - GotrokLugian */
+     , (451601702,   3,         13) /* PaletteTemplate - Purple */
+     , (451601702,   6,         -1) /* ItemsCapacity */
+     , (451601702,   7,         -1) /* ContainersCapacity */
+     , (451601702,   8,       8000) /* Mass */
+     , (451601702,  16,          1) /* ItemUseable - No */
+     , (451601702,  25,        999) /* Level */
+     , (451601702,  27,          0) /* ArmorType - None */
+     , (451601702,  40,          2) /* CombatMode - Melee */
+     , (451601702,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (451601702,  72,          6) /* FriendType - Tumerok */
+     , (451601702,  81,          1) /* MaxGeneratedObjects */
+     , (451601702,  82,          1) /* InitGeneratedObjects */
+     , (451601702,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (451601702, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (451601702, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (451601702, 140,          1) /* AiOptions - CanOpenDoors */
+     , (451601702, 146,  100000000) /* XpOverride */
+     , (451601702, 307,         90) /* DamageRating */
+     , (451601702, 308,         35) /* DamageResistRating */
+     , (451601702, 313,         10) /* CritRating */
+     , (451601702, 314,         35) /* CritDamageRating */
+     , (451601702, 332,     100000) /* LuminanceAward */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (451601702,   1, True ) /* Stuck */
+     , (451601702,  11, False) /* IgnoreCollisions */
+     , (451601702,  12, True ) /* ReportCollisions */
+     , (451601702,  13, False) /* Ethereal */
+     , (451601702,  14, True ) /* GravityStatus */
+     , (451601702,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (451601702,   1,       5) /* HeartbeatInterval */
+     , (451601702,   2,       0) /* HeartbeatTimestamp */
+     , (451601702,   3,     0.9) /* HealthRate */
+     , (451601702,   4,       4) /* StaminaRate */
+     , (451601702,   5,       2) /* ManaRate */
+     , (451601702,  12,     0.5) /* Shade */
+     , (451601702,  13,    0.57) /* ArmorModVsSlash */
+     , (451601702,  14,    0.57) /* ArmorModVsPierce */
+     , (451601702,  15,    0.57) /* ArmorModVsBludgeon */
+     , (451601702,  16,    0.36) /* ArmorModVsCold */
+     , (451601702,  17,    0.17) /* ArmorModVsFire */
+     , (451601702,  18,    0.86) /* ArmorModVsAcid */
+     , (451601702,  19,     0.7) /* ArmorModVsElectric */
+     , (451601702,  31,      43) /* VisualAwarenessRange */
+     , (451601702,  34,       1) /* PowerupTime */
+     , (451601702,  36,       1) /* ChargeSpeed */
+     , (451601702,  43,       3) /* GeneratorRadius */
+     , (451601702,  55,      45) /* HomeRadius */
+     , (451601702,  64,    0.66) /* ResistSlash */
+     , (451601702,  65,    0.66) /* ResistPierce */
+     , (451601702,  66,    0.66) /* ResistBludgeon */
+     , (451601702,  67,    0.25) /* ResistFire */
+     , (451601702,  68,    0.42) /* ResistCold */
+     , (451601702,  69,     0.9) /* ResistAcid */
+     , (451601702,  70,       1) /* ResistElectric */
+     , (451601702,  71,       1) /* ResistHealthBoost */
+     , (451601702,  72,       1) /* ResistStaminaDrain */
+     , (451601702,  73,       1) /* ResistStaminaBoost */
+     , (451601702,  74,       1) /* ResistManaDrain */
+     , (451601702,  75,       1) /* ResistManaBoost */
+     , (451601702, 104,      10) /* ObviousRadarRange */
+     , (451601702, 117,     0.5) /* FocusedProbability */
+     , (451601702, 125,       1) /* ResistHealthDrain */
+     , (451601702, 151,       1) /* IgnoreShield */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (451601702,   1, 'Commander Dickus') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (451601702,   1, 0x02000A0B) /* Setup */
+     , (451601702,   2, 0x09000006) /* MotionTable */
+     , (451601702,   3, 0x2000000A) /* SoundTable */
+     , (451601702,   4, 0x30000003) /* CombatTable */
+     , (451601702,   6, 0x040010C6) /* PaletteBase */
+     , (451601702,   7, 0x100002BA) /* ClothingBase */
+     , (451601702,   8, 0x06001037) /* Icon */
+     , (451601702,  22, 0x3400001E) /* PhysicsEffectTable */
+     , (451601702,  35,      10020) /* DeathTreasureType */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (451601702,   1,1500, 0, 0) /* Strength */
+     , (451601702,   2, 800, 0, 0) /* Endurance */
+     , (451601702,   3, 305, 0, 0) /* Quickness */
+     , (451601702,   4, 310, 0, 0) /* Coordination */
+     , (451601702,   5, 200, 0, 0) /* Focus */
+     , (451601702,   6, 240, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (451601702,   1,169600, 0, 0,170000) /* MaxHealth */
+     , (451601702,   3, 89200, 0, 0,90000) /* MaxStamina */
+     , (451601702,   5,     0, 0, 0,  240) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (451601702,  6, 0, 3, 0, 570, 0, 0) /* MeleeDefense        Specialized */
+     , (451601702,  7, 0, 3, 0, 627, 0, 0) /* MissileDefense      Specialized */
+     , (451601702, 15, 0, 2, 0, 408, 0, 0) /* MagicDefense             Trained */
+     , (451601702, 20, 0, 3, 0, 695, 0, 0) /* Deception           Specialized */
+     , (451601702, 24, 0, 2, 0,  45, 0, 0) /* Run                 Trained */
+     , (451601702, 44, 0, 2, 0,4950, 0, 0) /* HeavyWeapons        Trained */
+     , (451601702, 45, 0, 3, 0,4950, 0, 0) /* LightWeapons        Specialized */
+     , (451601702, 47, 0, 3, 0, 950, 0, 0) /* MissileWeapons      Specialized */
+     , (451601702, 51, 0, 3, 0, 695, 0, 0) /* SneakAttack         Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (451601702,  0,  4,  2,  0.3,  364,  207,  207,  207,  131,   61,  313,  291,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451601702,  1,  4, 40,  0.3,  371,  211,  211,  211,  133,   63,  319,  296,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451601702,  2,  4,  2,  0.3,  371,  211,  211,  211,  133,   63,  319,  296,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451601702,  3,  4,  2,  0.3,  350,  200,  200,  200,  126,   60,  301,  280,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451601702,  4,  4,  2,  0.3,  371,  211,  211,  211,  133,   63,  319,  296,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451601702,  5,  4, 20, 0.75,  315,  179,  179,  179,  113,   53,  271,  252,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451601702,  6,  4,  2,  0.3,  365,  208,  208,  208,  130,   60,  313,  291,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451601702,  7,  4, 25,  0.3,  365,  208,  208,  208,  130,   60,  313,  291,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451601702,  8,  4, 20, 0.75,  365,  208,  208,  208,  130,   60,  313,  291,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 3 /* Death */, 0.001, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 8 /* Say */, 0, 0, NULL, 'lmao zerg more losers.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.125, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.025, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 5 /* HeartBeat */, 0.125, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 16 /* KillTaunt */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'When you see your friends at the lifestone, tell them Biggus Dickus sent you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 18 /* Scream */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 8 /* Say */, 0, 0, NULL, 'Foolish Isparians, stick to killing metas!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 18 /* Scream */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 8 /* Say */, 0, 0, NULL, 'Get a job, eggneck.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (451601702, 21 /* ResistSpell */, 0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'I gather you are not a mighty wizard among your kind.  You should delete your account, scrub.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 1,361843,  1, 0,    1, False) /* Create Dick of Biggus (361843) for Contain */
+     , (451601702, 2, 23739,  0, 0,    0, False) /* Create Lugian Axe (23739) for Wield */;
+

--- a/Content/sql/weenies/T9Dungeons/451604984 Gelidite Acolyte.sql
+++ b/Content/sql/weenies/T9Dungeons/451604984 Gelidite Acolyte.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451604984;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451604984, 'T9lichfrore', 10, '2026-04-29 01:56:39') /* Creature */;
+VALUES (451604984, 'T9lichfrore', 10, '2026-04-30 07:51:34') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451604984,   1,         16) /* ItemType - Creature */
@@ -21,8 +21,8 @@ VALUES (451604984,   1,         16) /* ItemType - Creature */
      , (451604984, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451604984, 140,          1) /* AiOptions - CanOpenDoors */
      , (451604984, 146,   50000000) /* XpOverride */
-     , (451604984, 307,        165) /* DamageRating */
-     , (451604984, 308,         35) /* DamageResistRating */
+     , (451604984, 307,        120) /* DamageRating */
+     , (451604984, 308,         30) /* DamageResistRating */
      , (451604984, 332,       5000) /* LuminanceAward */
      , (451604984, 386,         25) /* Overpower */;
 
@@ -47,7 +47,7 @@ VALUES (451604984,   1,       5) /* HeartbeatInterval */
      , (451604984,  14,       1) /* ArmorModVsPierce */
      , (451604984,  15,       1) /* ArmorModVsBludgeon */
      , (451604984,  16,       1) /* ArmorModVsCold */
-     , (451604984,  17,       1) /* ArmorModVsFire */
+     , (451604984,  17,    0.75) /* ArmorModVsFire */
      , (451604984,  18,       1) /* ArmorModVsAcid */
      , (451604984,  19,       1) /* ArmorModVsElectric */
      , (451604984,  31,      18) /* VisualAwarenessRange */
@@ -85,7 +85,7 @@ VALUES (451604984,   1, 0x02000197) /* Setup */
      , (451604984,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451604984,   1,2600, 0, 0) /* Strength */
+VALUES (451604984,   1,2300, 0, 0) /* Strength */
      , (451604984,   2,2100, 0, 0) /* Endurance */
      , (451604984,   3, 850, 0, 0) /* Quickness */
      , (451604984,   4,1200, 0, 0) /* Coordination */
@@ -93,15 +93,15 @@ VALUES (451604984,   1,2600, 0, 0) /* Strength */
      , (451604984,   6, 650, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451604984,   1, 30950, 0, 0,32000) /* MaxHealth */
+VALUES (451604984,   1, 20950, 0, 0,22000) /* MaxHealth */
      , (451604984,   3, 12900, 0, 0,15000) /* MaxStamina */
      , (451604984,   5, 14350, 0, 0,15000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451604984,  6, 0, 3, 0,  97, 0, 0) /* MeleeDefense         Specialized */
-     , (451604984,  7, 0, 3, 0, 390, 0, 0) /* MissileDefense       Specialized */
+VALUES (451604984,  6, 0, 2, 0,  92, 0, 0) /* MeleeDefense             Trained */
+     , (451604984,  7, 0, 2, 0, 365, 0, 0) /* MissileDefense           Trained */
      , (451604984, 14, 0, 3, 0, 150, 0, 0) /* ArcaneLore          Specialized */
-     , (451604984, 15, 0, 3, 0, 229, 0, 0) /* MagicDefense         Specialized */
+     , (451604984, 15, 0, 3, 0, 209, 0, 0) /* MagicDefense         Specialized */
      , (451604984, 20, 0, 3, 0, 306, 0, 0) /* Deception            Specialized */
      , (451604984, 31, 0, 3, 0, 940, 0, 0) /* CreatureEnchantment Specialized */
      , (451604984, 33, 0, 3, 0, 940, 0, 0) /* LifeMagic           Specialized */
@@ -113,23 +113,22 @@ VALUES (451604984,  6, 0, 3, 0,  97, 0, 0) /* MeleeDefense         Specialized *
      , (451604984, 48, 0, 3, 0, 215, 0, 0) /* Shield              Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451604984,  0,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451604984,  1,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451604984,  2,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451604984,  3,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451604984,  4,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451604984,  5,  4, 80, 0.75,  345,  345,  345,  345,  345,  345,  345,  345,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451604984,  6,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451604984,  7,  4,  0,    0,  345,  345,  345,  345,  345,  345,  345,  345,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451604984,  8,  4, 80, 0.75,  345,  345,  345,  345,  345,  345,  345,  345,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451604984,  0,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451604984,  1,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451604984,  2,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451604984,  3,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451604984,  4,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451604984,  5,  4,100, 0.75,  245,  245,  245,  245,  245,  245,  245,  245,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451604984,  6,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451604984,  7,  4,  0,    0,  245,  245,  245,  245,  245,  245,  245,  245,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451604984,  8,  4,100, 0.75,  245,  245,  245,  245,  245,  245,  245,  245,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451604984,  4208,    2.1) /* Spectral Flame */
      , (451604984,  4643,   2.02) /* Incantation of Drain Health Other */
      , (451604984,  4449,    2.1) /* Incantation of Frost Volley */
      , (451604984,  4448,    2.1) /* Incantation of Frost Streak */
-     , (451604984,  4009,   2.06) /* Frost Wave */
-     , (451604984,  4312,   2.04) /* Incantation of Imperil Other */;
+     , (451604984,  4009,   2.04) /* Frost Wave */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (451604984, 9,361847,  1, 0, 0.04, False) /* Create Frore Shard (361847) for ContainTreasure */

--- a/Content/sql/weenies/T9Dungeons/451604986 Gelidite Initiate.sql
+++ b/Content/sql/weenies/T9Dungeons/451604986 Gelidite Initiate.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451604986;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451604986, 'T9451604986undeadfrore', 10, '2026-04-29 01:56:26') /* Creature */;
+VALUES (451604986, 'T9451604986undeadfrore', 10, '2026-04-30 07:43:59') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451604986,   1,         16) /* ItemType - Creature */
@@ -21,7 +21,7 @@ VALUES (451604986,   1,         16) /* ItemType - Creature */
      , (451604986, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451604986, 140,          1) /* AiOptions - CanOpenDoors */
      , (451604986, 146,   40000000) /* XpOverride */
-     , (451604986, 307,        135) /* DamageRating */
+     , (451604986, 307,        100) /* DamageRating */
      , (451604986, 308,         25) /* DamageResistRating */
      , (451604986, 332,       4000) /* LuminanceAward */
      , (451604986, 386,         25) /* Overpower */;
@@ -47,7 +47,7 @@ VALUES (451604986,   1,       5) /* HeartbeatInterval */
      , (451604986,  14,       1) /* ArmorModVsPierce */
      , (451604986,  15,       1) /* ArmorModVsBludgeon */
      , (451604986,  16,       1) /* ArmorModVsCold */
-     , (451604986,  17,       1) /* ArmorModVsFire */
+     , (451604986,  17,    0.75) /* ArmorModVsFire */
      , (451604986,  18,       1) /* ArmorModVsAcid */
      , (451604986,  19,       1) /* ArmorModVsElectric */
      , (451604986,  31,      18) /* VisualAwarenessRange */
@@ -93,15 +93,15 @@ VALUES (451604986,   1,2300, 0, 0) /* Strength */
      , (451604986,   6, 650, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451604986,   1, 26950, 0, 0,28000) /* MaxHealth */
+VALUES (451604986,   1, 18950, 0, 0,20000) /* MaxHealth */
      , (451604986,   3, 12900, 0, 0,15000) /* MaxStamina */
      , (451604986,   5, 14350, 0, 0,15000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451604986,  6, 0, 3, 0, 117, 0, 0) /* MeleeDefense         Specialized */
+VALUES (451604986,  6, 0, 2, 0,  87, 0, 0) /* MeleeDefense             Trained */
      , (451604986,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense       Specialized */
      , (451604986, 14, 0, 3, 0, 150, 0, 0) /* ArcaneLore          Specialized */
-     , (451604986, 15, 0, 3, 0, 204, 0, 0) /* MagicDefense         Specialized */
+     , (451604986, 15, 0, 2, 0, 204, 0, 0) /* MagicDefense             Trained */
      , (451604986, 20, 0, 3, 0, 306, 0, 0) /* Deception            Specialized */
      , (451604986, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
      , (451604986, 33, 0, 3, 0, 125, 0, 0) /* LifeMagic            Specialized */
@@ -113,15 +113,15 @@ VALUES (451604986,  6, 0, 3, 0, 117, 0, 0) /* MeleeDefense         Specialized *
      , (451604986, 48, 0, 3, 0, 215, 0, 0) /* Shield              Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451604986,  0,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451604986,  1,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451604986,  2,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451604986,  3,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451604986,  4,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451604986,  5,  4, 80, 0.75,  288,  288,  288,  288,  288,  288,  288,  288,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451604986,  6,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451604986,  7,  4,  0,    0,  288,  288,  288,  288,  288,  288,  288,  288,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451604986,  8,  4, 80, 0.75,  288,  288,  288,  288,  288,  288,  288,  288,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451604986,  0,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451604986,  1,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451604986,  2,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451604986,  3,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451604986,  4,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451604986,  5,  4, 80, 0.75,  216,  216,  216,  216,  216,  216,  216,  216,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451604986,  6,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451604986,  7,  4,  0,    0,  216,  216,  216,  216,  216,  216,  216,  216,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451604986,  8,  4, 80, 0.75,  216,  216,  216,  216,  216,  216,  216,  216,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451604986,  4208,    2.1) /* Spectral Flame */

--- a/Content/sql/weenies/T9Dungeons/451605868 Gelidite Lord.sql
+++ b/Content/sql/weenies/T9Dungeons/451605868 Gelidite Lord.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451605868;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451605868, 'T9lichlordfrore', 10, '2026-04-29 01:56:55') /* Creature */;
+VALUES (451605868, 'T9lichlordfrore', 10, '2026-04-30 07:51:55') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451605868,   1,         16) /* ItemType - Creature */
@@ -22,8 +22,8 @@ VALUES (451605868,   1,         16) /* ItemType - Creature */
      , (451605868, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451605868, 140,          1) /* AiOptions - CanOpenDoors */
      , (451605868, 146,   80000000) /* XpOverride */
-     , (451605868, 307,        200) /* DamageRating */
-     , (451605868, 308,         45) /* DamageResistRating */
+     , (451605868, 307,        140) /* DamageRating */
+     , (451605868, 308,         30) /* DamageResistRating */
      , (451605868, 332,       6000) /* LuminanceAward */
      , (451605868, 386,         45) /* Overpower */;
 
@@ -48,7 +48,7 @@ VALUES (451605868,   1,       5) /* HeartbeatInterval */
      , (451605868,  14,       1) /* ArmorModVsPierce */
      , (451605868,  15,       1) /* ArmorModVsBludgeon */
      , (451605868,  16,       1) /* ArmorModVsCold */
-     , (451605868,  17,       1) /* ArmorModVsFire */
+     , (451605868,  17,    0.75) /* ArmorModVsFire */
      , (451605868,  18,       1) /* ArmorModVsAcid */
      , (451605868,  19,       1) /* ArmorModVsElectric */
      , (451605868,  31,      18) /* VisualAwarenessRange */
@@ -88,7 +88,7 @@ VALUES (451605868,   1, 0x02000197) /* Setup */
      , (451605868,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451605868,   1,3000, 0, 0) /* Strength */
+VALUES (451605868,   1,2300, 0, 0) /* Strength */
      , (451605868,   2,2100, 0, 0) /* Endurance */
      , (451605868,   3, 850, 0, 0) /* Quickness */
      , (451605868,   4,1200, 0, 0) /* Coordination */
@@ -96,15 +96,15 @@ VALUES (451605868,   1,3000, 0, 0) /* Strength */
      , (451605868,   6,1600, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451605868,   1, 34950, 0, 0,36000) /* MaxHealth */
+VALUES (451605868,   1, 23950, 0, 0,25000) /* MaxHealth */
      , (451605868,   3, 12900, 0, 0,15000) /* MaxStamina */
      , (451605868,   5, 13400, 0, 0,15000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451605868,  6, 0, 3, 0, 117, 0, 0) /* MeleeDefense         Specialized */
+VALUES (451605868,  6, 0, 2, 0,  92, 0, 0) /* MeleeDefense             Trained */
      , (451605868,  7, 0, 3, 0, 390, 0, 0) /* MissileDefense       Specialized */
      , (451605868, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
-     , (451605868, 15, 0, 3, 0,  43, 0, 0) /* MagicDefense         Specialized */
+     , (451605868, 15, 0, 2, 0,  28, 0, 0) /* MagicDefense             Trained */
      , (451605868, 20, 0, 3, 0, 306, 0, 0) /* Deception            Specialized */
      , (451605868, 31, 0, 3, 0,1220, 0, 0) /* CreatureEnchantment Specialized */
      , (451605868, 33, 0, 3, 0,1220, 0, 0) /* LifeMagic           Specialized */
@@ -116,24 +116,23 @@ VALUES (451605868,  6, 0, 3, 0, 117, 0, 0) /* MeleeDefense         Specialized *
      , (451605868, 48, 0, 3, 0,1280, 0, 0) /* Shield              Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451605868,  0,  4,  0,    0,  356,  356,  356,  356,  356,  356,  356,  356,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451605868,  1,  4,  0,    0,  341,  341,  341,  341,  341,  341,  341,  341,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451605868,  2,  4,  0,    0,  341,  341,  341,  341,  341,  341,  341,  341,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451605868,  3,  4,  0,    0,  341,  341,  341,  341,  341,  341,  341,  341,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451605868,  4,  4,  0,    0,  341,  341,  341,  341,  341,  341,  341,  341,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451605868,  5,  4, 80, 0.75,  341,  341,  341,  341,  341,  341,  341,  341,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451605868,  6,  4,  0,    0,  341,  341,  341,  341,  341,  341,  341,  341,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451605868,  7,  4,  0,    0,  341,  341,  341,  341,  341,  341,  341,  341,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451605868,  8,  4, 80, 0.75,  341,  341,  341,  341,  341,  341,  341,  341,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451605868,  0,  4,  0,    0,  249,  249,  249,  249,  249,  249,  249,  249,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451605868,  1,  4,  0,    0,  238,  238,  238,  238,  238,  238,  238,  238,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451605868,  2,  4,  0,    0,  238,  238,  238,  238,  238,  238,  238,  238,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451605868,  3,  4,  0,    0,  238,  238,  238,  238,  238,  238,  238,  238,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451605868,  4,  4,  0,    0,  238,  238,  238,  238,  238,  238,  238,  238,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451605868,  5,  4, 80, 0.75,  238,  238,  238,  238,  238,  238,  238,  238,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451605868,  6,  4,  0,    0,  238,  238,  238,  238,  238,  238,  238,  238,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451605868,  7,  4,  0,    0,  238,  238,  238,  238,  238,  238,  238,  238,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451605868,  8,  4, 80, 0.75,  238,  238,  238,  238,  238,  238,  238,  238,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451605868,  4208,   2.08) /* Spectral Flame */
-     , (451605868,  4449,   2.07) /* Incantation of Frost Volley */
-     , (451605868,  4643,   2.03) /* Incantation of Drain Health Other */
-     , (451605868,  4448,   2.07) /* Incantation of Frost Streak */
-     , (451605868,  6193,   2.03) /* Halo of Frost II */
-     , (451605868,  4312,   2.03) /* Incantation of Imperil Other */
-     , (451605868,  4009,   2.03) /* Frost Wave */;
+     , (451605868,  4449,   2.05) /* Incantation of Frost Volley */
+     , (451605868,  4643,   2.02) /* Incantation of Drain Health Other */
+     , (451605868,  4448,   2.06) /* Incantation of Frost Streak */
+     , (451605868,  6193,   2.04) /* Halo of Frost II */
+     , (451605868,  4009,   2.04) /* Frost Wave */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (451605868, 9,361847,  1, 0, 0.04, False) /* Create Frore Shard (361847) for ContainTreasure */

--- a/Content/sql/weenies/T9Dungeons/451608138 Extas Raider.sql
+++ b/Content/sql/weenies/T9Dungeons/451608138 Extas Raider.sql
@@ -91,7 +91,7 @@ VALUES (451608138,   1, 385, 0, 0) /* Strength */
      , (451608138,   6, 240, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451608138,   1, 11590, 0, 0,11760) /* MaxHealth */
+VALUES (451608138,   1, 11590, 0, 0,18000) /* MaxHealth */
      , (451608138,   3,  8670, 0, 0, 9010) /* MaxStamina */
      , (451608138,   5,     0, 0, 0,  240) /* MaxMana */;
 

--- a/Content/sql/weenies/T9Dungeons/451624285 Raider Juggernaut.sql
+++ b/Content/sql/weenies/T9Dungeons/451624285 Raider Juggernaut.sql
@@ -92,7 +92,7 @@ VALUES (451624285,   1, 500, 0, 0) /* Strength */
      , (451624285,   6, 240, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451624285,   1, 14590, 0, 0,14760) /* MaxHealth */
+VALUES (451624285,   1, 14590, 0, 0, 19000) /* MaxHealth */
      , (451624285,   3,  8670, 0, 0, 9010) /* MaxStamina */
      , (451624285,   5,     0, 0, 0,  240) /* MaxMana */;
 

--- a/Content/sql/weenies/T9Dungeons/451624495 Gotrok Juggernaut.sql
+++ b/Content/sql/weenies/T9Dungeons/451624495 Gotrok Juggernaut.sql
@@ -91,7 +91,7 @@ VALUES (451624495,   1, 650, 0, 0) /* Strength */
      , (451624495,   6, 240, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451624495,   1, 16590, 0, 0,16760) /* MaxHealth */
+VALUES (451624495,   1, 16590, 0, 0, 21000) /* MaxHealth */
      , (451624495,   3,  8670, 0, 0, 9010) /* MaxStamina */
      , (451624495,   5,     0, 0, 0,  240) /* MaxMana */;
 

--- a/Content/sql/weenies/T9Dungeons/451624497 Gotrok Tiatus.sql
+++ b/Content/sql/weenies/T9Dungeons/451624497 Gotrok Tiatus.sql
@@ -92,7 +92,7 @@ VALUES (451624497,   1,1250, 0, 0) /* Strength */
      , (451624497,   6, 240, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451624497,   1, 14590, 0, 0,14760) /* MaxHealth */
+VALUES (451624497,   1, 14590, 0, 0, 19000) /* MaxHealth */
      , (451624497,   3,  8670, 0, 0, 9010) /* MaxStamina */
      , (451624497,   5,     0, 0, 0,  240) /* MaxMana */;
 

--- a/Content/sql/weenies/T9Dungeons/451626008 Gelidite Golem.sql
+++ b/Content/sql/weenies/T9Dungeons/451626008 Gelidite Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 451626008;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (451626008, 'T9golemgelidite', 10, '2026-04-29 01:49:38') /* Creature */;
+VALUES (451626008, 'T9golemgelidite', 10, '2026-04-30 08:00:57') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (451626008,   1,         16) /* ItemType - Creature */
@@ -18,7 +18,7 @@ VALUES (451626008,   1,         16) /* ItemType - Creature */
      , (451626008,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (451626008, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (451626008, 146,   38000000) /* XpOverride */
-     , (451626008, 307,        200) /* DamageRating */
+     , (451626008, 307,         80) /* DamageRating */
      , (451626008, 332,       6000) /* LuminanceAward */
      , (451626008, 386,         40) /* Overpower */;
 
@@ -44,9 +44,9 @@ VALUES (451626008,   1,       5) /* HeartbeatInterval */
      , (451626008,  12,     0.5) /* Shade */
      , (451626008,  13,    0.79) /* ArmorModVsSlash */
      , (451626008,  14,     0.9) /* ArmorModVsPierce */
-     , (451626008,  15,       1) /* ArmorModVsBludgeon */
+     , (451626008,  15,    0.75) /* ArmorModVsBludgeon */
      , (451626008,  16,    0.84) /* ArmorModVsCold */
-     , (451626008,  17,    0.84) /* ArmorModVsFire */
+     , (451626008,  17,    0.75) /* ArmorModVsFire */
      , (451626008,  18,    0.84) /* ArmorModVsAcid */
      , (451626008,  19,    0.84) /* ArmorModVsElectric */
      , (451626008,  31,      17) /* VisualAwarenessRange */
@@ -84,23 +84,23 @@ VALUES (451626008,   1, 0x020007D7) /* Setup */
      , (451626008,  35,      10022) /* DeathTreasureType */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (451626008,   1,3500, 0, 0) /* Strength */
-     , (451626008,   2,20000, 0, 0) /* Endurance */
+VALUES (451626008,   1,3200, 0, 0) /* Strength */
+     , (451626008,   2,2000, 0, 0) /* Endurance */
      , (451626008,   3, 500, 0, 0) /* Quickness */
      , (451626008,   4,1200, 0, 0) /* Coordination */
      , (451626008,   5,2200, 0, 0) /* Focus */
      , (451626008,   6,1200, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (451626008,   1, 22000, 0, 0,32000) /* MaxHealth */
-     , (451626008,   3,     0, 0, 0,20000) /* MaxStamina */
-     , (451626008,   5, 13800, 0, 0,15000) /* MaxMana */;
+VALUES (451626008,   1, 22000, 0, 0,23000) /* MaxHealth */
+     , (451626008,   3, 22000, 0, 0,24000) /* MaxStamina */
+     , (451626008,   5, 20800, 0, 0,22000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (451626008,  6, 0, 3, 0, 204, 0, 0) /* MeleeDefense         Specialized */
+VALUES (451626008,  6, 0, 2, 0, 204, 0, 0) /* MeleeDefense             Trained */
      , (451626008,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense       Specialized */
      , (451626008, 14, 0, 3, 0, 300, 0, 0) /* ArcaneLore          Specialized */
-     , (451626008, 15, 0, 3, 0,  15, 0, 0) /* MagicDefense         Specialized */
+     , (451626008, 15, 0, 2, 0, 101, 0, 0) /* MagicDefense             Trained */
      , (451626008, 20, 0, 3, 0, 400, 0, 0) /* Deception            Specialized */
      , (451626008, 22, 0, 2, 0,  10, 0, 0) /* Jump                Trained */
      , (451626008, 24, 0, 2, 0,  10, 0, 0) /* Run                 Trained */
@@ -110,23 +110,22 @@ VALUES (451626008,  6, 0, 3, 0, 204, 0, 0) /* MeleeDefense         Specialized *
      , (451626008, 45, 0, 3, 0,1175, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (451626008,  0,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
-     , (451626008,  1,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
-     , (451626008,  2,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
-     , (451626008,  3,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
-     , (451626008,  4,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
-     , (451626008,  5,  4, 90, 0.75,  420,  332,  378,  420,  352,  352,  352,  352,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
-     , (451626008,  6,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
-     , (451626008,  7,  4,  0,    0,  420,  332,  378,  420,  352,  352,  352,  352,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
-     , (451626008,  8,  4, 90, 0.75,  420,  332,  378,  420,  352,  352,  352,  352,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
+VALUES (451626008,  0,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head - Bludgeon */
+     , (451626008,  1,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest - Bludgeon */
+     , (451626008,  2,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen - Bludgeon */
+     , (451626008,  3,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm - Bludgeon */
+     , (451626008,  4,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm - Bludgeon */
+     , (451626008,  5,  4, 90, 0.75,  315,  249,  283,  315,  264,  264,  264,  264,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand - Bludgeon */
+     , (451626008,  6,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg - Bludgeon */
+     , (451626008,  7,  4,  0,    0,  315,  249,  283,  315,  264,  264,  264,  264,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg - Bludgeon */
+     , (451626008,  8,  4, 90, 0.75,  315,  249,  283,  315,  264,  264,  264,  264,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot - Bludgeon */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (451626008,  4449,   2.08) /* Incantation of Frost Volley */
-     , (451626008,  4579,  2.048) /* Incantation of Life Magic Ineptitude Other */
-     , (451626008,  4312,  2.048) /* Incantation of Imperil Other */
-     , (451626008,  4643,   2.05) /* Incantation of Drain Health Other */
-     , (451626008,  4326,  2.048) /* Incantation of Weakness Other */
-     , (451626008,  4208,   2.08) /* Spectral Flame */;
+     , (451626008,  4579,   2.05) /* Incantation of Life Magic Ineptitude Other */
+     , (451626008,  4643,   2.02) /* Incantation of Drain Health Other */
+     , (451626008,  4326,   2.02) /* Incantation of Weakness Other */
+     , (451626008,  4208,   2.07) /* Spectral Flame */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (451626008, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Balanced mobs thruout based on fuckin around on test serve. Mostly hp and armor were too high. for some reason it renamed files of the BSD and citadel bosses. also put faster generator in BSD and up luggies hp a bit to encourage folks to go to new places